### PR TITLE
Replace Os with O3 for a 3x speedboost

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,7 +38,7 @@ set(THREAD_LIBS Threads::Threads)
 
 if(EMSCRIPTEN)
   if(CMAKE_BUILD_TYPE MATCHES Release)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
   endif()
 
   if(WITH_WASM_EXCEPTIONS)
@@ -147,7 +147,7 @@ if(EMSCRIPTEN)
   if(WASM_FAST_LINKING)
     set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -O0")
   else()
-    set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -Os")
+    set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -O3")
   endif()
 
   add_executable(duckdb_wasm ${CMAKE_SOURCE_DIR}/src/wasm_main.cc)


### PR DESCRIPTION
Discovered during benchmark development

```
-O3
11MB wasm
Running "Simple primary key join" suite...
DuckDB t: 0.09402s ±2.52% (51 samples)
Running "TPCH query" suite...
DuckDB t: 0.43630s ±4.40% (16 samples)

-Os
6MB wasm
Running "Simple primary key join" suite...
DuckDB t: 0.29198s ±1.29% (21 samples)
Running "TPCH query" suite...
DuckDB t: 1.18935s ±2.16% (9 samples)
```