### PR TITLE
Fix file permissions on opensync call

### DIFF
--- a/packages/duckdb/src/bindings/runtime_node.ts
+++ b/packages/duckdb/src/bindings/runtime_node.ts
@@ -26,7 +26,8 @@ function tmpFile() {
 const openFile = (path: string) => {
     const fd = fs.openSync(
         path,
-        fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.S_IRUSR | fs.constants.S_IWUSR,
+        fs.constants.O_CREAT | fs.constants.O_RDWR,
+        fs.constants.S_IRUSR | fs.constants.S_IWUSR,
     );
     const stat = fs.fstatSync(fd);
     const fileID = NodeRuntime.nextFileID++;


### PR DESCRIPTION
The read write permissions are a separate parameter unlike currently used, leading to errors when opening files as the flags are misinterpreted.

PS: Additionally, with current master i receive a memory access out of bounds error all of a sudden, will probably open second PR once fixed.