### PR TITLE
Add Node non-eh target

### DIFF
--- a/packages/duckdb/bundle.mjs
+++ b/packages/duckdb/bundle.mjs
@@ -138,6 +138,19 @@ esbuild.build({
 // -------------------------------
 // NODE
 
+console.log('[ ESBUILD ] duckdb-node-sync.js');
+esbuild.build({
+    entryPoints: ['./src/targets/duckdb-node-sync.ts'],
+    outfile: 'dist/duckdb-node-sync.js',
+    platform: 'node',
+    format: 'cjs',
+    target: TARGET,
+    bundle: true,
+    minify: true,
+    sourcemap: 'external',
+    external: EXTERNALS,
+});
+
 console.log('[ ESBUILD ] duckdb-node-sync-eh.js');
 esbuild.build({
     entryPoints: ['./src/targets/duckdb-node-sync-eh.ts'],
@@ -155,6 +168,19 @@ console.log('[ ESBUILD ] duckdb-node-async.js');
 esbuild.build({
     entryPoints: ['./src/targets/duckdb-node-async.ts'],
     outfile: 'dist/duckdb-node-async.js',
+    platform: 'node',
+    format: 'cjs',
+    target: TARGET,
+    bundle: true,
+    minify: true,
+    sourcemap: 'external',
+    external: EXTERNALS,
+});
+
+console.log('[ ESBUILD ] duckdb-node-async.worker.js');
+esbuild.build({
+    entryPoints: ['./src/targets/duckdb-node-async.worker.ts'],
+    outfile: 'dist/duckdb-node-async.worker.js',
     platform: 'node',
     format: 'cjs',
     target: TARGET,
@@ -241,6 +267,11 @@ fs.writeFile(
 );
 
 // Node declarations
+fs.writeFile(
+    path.join(dist, 'duckdb-node-sync.d.ts'),
+    "export * from './types/src/targets/duckdb-node-sync';",
+    printErr,
+);
 fs.writeFile(
     path.join(dist, 'duckdb-node-sync-eh.d.ts'),
     "export * from './types/src/targets/duckdb-node-sync-eh';",

--- a/packages/duckdb/src/bindings/bindings_node.ts
+++ b/packages/duckdb/src/bindings/bindings_node.ts
@@ -1,0 +1,21 @@
+import DuckDBWasm from './duckdb_wasm.js';
+import { DuckDBNodeBindings } from './bindings_node_base.js';
+import { Logger } from '../log.js';
+import { DuckDBModule } from './duckdb_module';
+import { DuckDBRuntime } from './runtime_base';
+
+/** DuckDB bindings for node.js */
+export class DuckDB extends DuckDBNodeBindings {
+    /** Constructor */
+    public constructor(logger: Logger, runtime: DuckDBRuntime, path: string) {
+        super(logger, runtime, path);
+    }
+
+    /** Instantiate the bindings */
+    protected instantiate(moduleOverrides: Partial<DuckDBModule>): Promise<DuckDBModule> {
+        return DuckDBWasm({
+            ...moduleOverrides,
+            instantiateWasm: this.instantiateWasm.bind(this),
+        });
+    }
+}

--- a/packages/duckdb/src/bindings/bindings_node_base.ts
+++ b/packages/duckdb/src/bindings/bindings_node_base.ts
@@ -1,0 +1,58 @@
+import DuckDBWasm from './duckdb_wasm.js';
+import { DuckDBModule } from './duckdb_module';
+import { DuckDBBindings } from './bindings';
+import { DuckDBRuntime } from './runtime_base';
+import { Logger } from '../log';
+import fs from 'fs';
+
+declare global {
+    // eslint-disable-next-line no-var
+    var DuckDBTrampoline: any;
+}
+
+/** DuckDB bindings for node.js */
+export class DuckDBNodeBindings extends DuckDBBindings {
+    /** The path of the wasm module */
+    protected path: string;
+
+    /** Constructor */
+    public constructor(logger: Logger, runtime: DuckDBRuntime, path: string) {
+        super(logger, runtime);
+        this.path = path;
+    }
+
+    /** Instantiate the wasm module */
+    protected instantiateWasm(
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+        imports: any,
+        success: (module: WebAssembly.Module) => void,
+    ): Emscripten.WebAssemblyExports {
+        const imports_rt: WebAssembly.Imports = {
+            ...imports,
+            env: {
+                ...imports.env,
+            },
+        };
+        const buf = fs.readFileSync(this.path);
+        WebAssembly.instantiate(buf, imports_rt).then(output => {
+            const module = output.instance;
+
+            globalThis.DuckDBTrampoline = {};
+
+            for (const func of Object.getOwnPropertyNames(this._runtime)) {
+                if (func == 'constructor') continue;
+                globalThis.DuckDBTrampoline[func] = Object.getOwnPropertyDescriptor(this._runtime, func)!.value;
+            }
+            success(module);
+        });
+        return [];
+    }
+
+    /** Instantiate the bindings */
+    protected instantiate(moduleOverrides: Partial<DuckDBModule>): Promise<DuckDBModule> {
+        return DuckDBWasm({
+            ...moduleOverrides,
+            instantiateWasm: this.instantiateWasm.bind(this),
+        });
+    }
+}

--- a/packages/duckdb/src/targets/duckdb-node-async.worker.ts
+++ b/packages/duckdb/src/targets/duckdb-node-async.worker.ts
@@ -1,0 +1,29 @@
+import { AsyncDuckDBDispatcher, WorkerResponseVariant, WorkerRequestVariant } from '../parallel/';
+import { DuckDBBindings } from '../bindings';
+import { DuckDB } from '../bindings/bindings_node';
+import Runtime from '../bindings/runtime_node';
+
+/** The duckdb worker API for node.js workers */
+class NodeWorker extends AsyncDuckDBDispatcher {
+    /** Post a response back to the main thread */
+    protected postMessage(response: WorkerResponseVariant, transfer: ArrayBuffer[]) {
+        globalThis.postMessage(response, transfer);
+    }
+
+    /** Instantiate the wasm module */
+    protected async open(path: string): Promise<DuckDBBindings> {
+        const bindings = new DuckDB(this, Runtime, path);
+        await bindings.open();
+        return bindings;
+    }
+}
+
+/** Register the worker */
+export function registerWorker(): void {
+    const api = new NodeWorker();
+    globalThis.onmessage = async (event: MessageEvent<WorkerRequestVariant>) => {
+        await api.onMessage(event.data);
+    };
+}
+
+registerWorker();

--- a/packages/duckdb/src/targets/duckdb-node-sync.ts
+++ b/packages/duckdb/src/targets/duckdb-node-sync.ts
@@ -1,0 +1,6 @@
+export * from '../log';
+export * from '../status';
+export * from '../bindings';
+export * from '../bindings/bindings_node';
+export { NodeRuntime } from '../bindings/runtime_node';
+export { MinimalRuntime } from '../bindings/runtime_minimal';

--- a/packages/duckdb/test/index_node.ts
+++ b/packages/duckdb/test/index_node.ts
@@ -6,8 +6,10 @@ import fs from 'fs';
 
 // Configure the worker
 const WORKER_CONFIG = duckdb_async.configure({
-    worker: path.resolve(__dirname, './duckdb-node-async-eh.worker.js'),
-    wasm: path.resolve(__dirname, './duckdb-eh.wasm'),
+    worker: path.resolve(__dirname, './duckdb-node-async.worker.js'),
+    workerEH: path.resolve(__dirname, './duckdb-node-async-eh.worker.js'),
+    wasm: path.resolve(__dirname, './duckdb.wasm'),
+    wasmEH: path.resolve(__dirname, './duckdb-eh.wasm'),
 });
 
 // Loading debug symbols, especially for WASM take insanely long so we just disable the test timeout


### PR DESCRIPTION
Debugging doesn't seem to work (as well) in node when using eh builds, also it seems that chrome devtools cant parse the debug symbols or something with eh