### PR TITLE
Make open() return the bindings

### DIFF
--- a/packages/duckdb-wasm/src/bindings/bindings.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings.ts
@@ -53,10 +53,10 @@ export abstract class DuckDBBindings {
     protected abstract instantiate(moduleOverrides: Partial<DuckDBModule>): Promise<DuckDBModule>;
 
     /** Open the database */
-    public async open(): Promise<void> {
+    public async open(): Promise<this> {
         // Already opened?
         if (this._instance != null) {
-            return;
+            return this;
         }
         // Open in progress?
         if (this._openPromise != null) {
@@ -78,6 +78,8 @@ export abstract class DuckDBBindings {
         // Wait for onRuntimeInitialized
         await this._openPromise;
         this._openPromise = null;
+
+        return this;
     }
 
     /** Tokenize a script */

--- a/packages/duckdb-wasm/src/targets/duckdb-browser-async-next-coi.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-browser-async-next-coi.worker.ts
@@ -13,8 +13,7 @@ class WebWorker extends AsyncDuckDBDispatcher {
     /** Instantiate the wasm module */
     protected async open(mainModuleURL: string, pthreadWorkerURL: string | null): Promise<DuckDBBindings> {
         const bindings = new DuckDB(this, BROWSER_RUNTIME, mainModuleURL, pthreadWorkerURL);
-        await bindings.open();
-        return bindings;
+        return await bindings.open();
     }
 }
 

--- a/packages/duckdb-wasm/src/targets/duckdb-browser-async-next.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-browser-async-next.worker.ts
@@ -13,8 +13,7 @@ class WebWorker extends AsyncDuckDBDispatcher {
     /** Instantiate the wasm module */
     protected async open(mainModuleURL: string, pthreadWorkerURL: string | null): Promise<DuckDBBindings> {
         const bindings = new DuckDB(this, BROWSER_RUNTIME, mainModuleURL, pthreadWorkerURL);
-        await bindings.open();
-        return bindings;
+        return await bindings.open();
     }
 }
 

--- a/packages/duckdb-wasm/src/targets/duckdb-browser-async.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-browser-async.worker.ts
@@ -13,8 +13,7 @@ class WebWorker extends AsyncDuckDBDispatcher {
     /** Instantiate the wasm module */
     protected async open(mainModuleURL: string, pthreadWorkerURL: string | null): Promise<DuckDBBindings> {
         const bindings = new DuckDB(this, BROWSER_RUNTIME, mainModuleURL, pthreadWorkerURL);
-        await bindings.open();
-        return bindings;
+        return await bindings.open();
     }
 }
 

--- a/packages/duckdb-wasm/src/targets/duckdb-node-async-next.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-node-async-next.worker.ts
@@ -13,8 +13,7 @@ class NodeWorker extends AsyncDuckDBDispatcher {
     /** Instantiate the wasm module */
     protected async open(mainModulePath: string, pthreadWorkerPath: string | null): Promise<DuckDBBindings> {
         const bindings = new DuckDB(this, NODE_RUNTIME, mainModulePath, pthreadWorkerPath);
-        await bindings.open();
-        return bindings;
+        return await bindings.open();
     }
 }
 

--- a/packages/duckdb-wasm/src/targets/duckdb-node-async.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-node-async.worker.ts
@@ -13,8 +13,7 @@ class NodeWorker extends AsyncDuckDBDispatcher {
     /** Instantiate the wasm module */
     protected async open(mainModulePath: string, pthreadWorkerPath: string | null): Promise<DuckDBBindings> {
         const bindings = new DuckDB(this, NODE_RUNTIME, mainModulePath, pthreadWorkerPath);
-        await bindings.open();
-        return bindings;
+        return await bindings.open();
     }
 }
 

--- a/packages/duckdb-wasm/test/index_node.ts
+++ b/packages/duckdb-wasm/test/index_node.ts
@@ -48,8 +48,11 @@ beforeAll(async () => {
     });
 
     const logger = new duckdb_sync.VoidLogger();
-    db = new duckdb_sync.DuckDB(logger, duckdb_sync.NODE_RUNTIME, path.resolve(__dirname, './duckdb.wasm'));
-    await db.open();
+    db = await new duckdb_sync.DuckDB(
+        logger,
+        duckdb_sync.NODE_RUNTIME,
+        path.resolve(__dirname, './duckdb.wasm'),
+    ).open();
 
     worker = new Worker(DUCKDB_CONFIG.mainWorker);
     adb = new duckdb_async.AsyncDuckDB(logger, worker);


### PR DESCRIPTION
With this change, one can initialize a binding in one line of code.