### PR TITLE
Update README to use Uint8Array

### DIFF
--- a/packages/duckdb-wasm/README.md
+++ b/packages/duckdb-wasm/README.md
@@ -109,7 +109,7 @@ const pickedFile: File = letUserPickFile();
 await db.registerFileHandle('local.parquet', pickedFile);
 await db.registerFileURL('remote.parquet', 'https://origin/remote.parquet');
 const res = await fetch('https://origin/remote.parquet');
-await db.registerFileBuffer('buffer.parquet', await res.arrayBuffer());
+await db.registerFileBuffer('buffer.parquet', new Uint8Array(await res.arrayBuffer()));
 
 // ..., by specifying URLs in the SQL text
 await c.query(`


### PR DESCRIPTION
`registerFileBuffer` expects a`Uint8Array`, not an `ArrayBuffer`. This updates the parquet example in the readme to properly use that type.

See:
https://github.com/duckdb/duckdb-wasm/blob/84ead1066ee716731e30420dcae81f72e1fc7e7b/packages/duckdb-wasm/src/bindings/bindings_interface.ts#L31