### PR TITLE
feat: add castDurationToTime64 option

### DIFF
--- a/lib/include/duckdb/web/config.h
+++ b/lib/include/duckdb/web/config.h
@@ -46,7 +46,10 @@ struct QueryConfig {
     std::optional<bool> cast_duration_to_time64 = std::nullopt;
 
     /// Has any cast?
-    bool hasAnyCast() const { return cast_bigint_to_double.value_or(false) || cast_timestamp_to_date.value_or(false) || cast_duration_to_time64.value_or(false); }
+    bool hasAnyCast() const {
+        return cast_bigint_to_double.value_or(false) || cast_timestamp_to_date.value_or(false) ||
+               cast_duration_to_time64.value_or(false);
+    }
     /// Read from a document
     static QueryConfig ReadFrom(std::string_view args_json);
 };

--- a/lib/include/duckdb/web/config.h
+++ b/lib/include/duckdb/web/config.h
@@ -42,9 +42,11 @@ struct QueryConfig {
     std::optional<bool> cast_bigint_to_double = std::nullopt;
     /// Cast Timestamp[ms] to Date64
     std::optional<bool> cast_timestamp_to_date = std::nullopt;
+    /// Cast Duration to Time64
+    std::optional<bool> cast_duration_to_time64 = std::nullopt;
 
     /// Has any cast?
-    bool hasAnyCast() const { return cast_bigint_to_double.value_or(false) || cast_timestamp_to_date.value_or(false); }
+    bool hasAnyCast() const { return cast_bigint_to_double.value_or(false) || cast_timestamp_to_date.value_or(false) || cast_duration_to_time64.value_or(false); }
     /// Read from a document
     static QueryConfig ReadFrom(std::string_view args_json);
 };
@@ -63,6 +65,7 @@ struct WebDBConfig {
     QueryConfig query = {
         .cast_bigint_to_double = std::nullopt,
         .cast_timestamp_to_date = std::nullopt,
+        .cast_duration_to_time64 = std::nullopt,
     };
     /// The filesystem
     FileSystemConfig filesystem = {

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -42,6 +42,7 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
             QueryConfig{
                 .cast_bigint_to_double = std::nullopt,
                 .cast_timestamp_to_date = std::nullopt,
+                .cast_duration_to_time64 = true,
             },
         .filesystem = FileSystemConfig{.allow_full_http_reads = std::nullopt},
     };
@@ -61,6 +62,9 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
             }
             if (q.HasMember("castTimestampToDate") && q["castTimestampToDate"].IsBool()) {
                 config.query.cast_timestamp_to_date = q["castTimestampToDate"].GetBool();
+            }
+            if (q.HasMember("castDurationToTime64") && q["castDurationToTime64"].IsBool()) {
+                config.query.cast_duration_to_time64 = q["castDurationToTime64"].GetBool();
             }
         }
         if (doc.HasMember("filesystem") && doc["filesystem"].IsObject()) {

--- a/packages/duckdb-wasm/src/bindings/config.ts
+++ b/packages/duckdb-wasm/src/bindings/config.ts
@@ -7,6 +7,11 @@ export interface DuckDBQueryConfig {
      * Cast Timestamp to Date64?
      */
     castTimestampToDate?: boolean;
+    /**
+     * Cast Timestamp to Date64?
+     * Note that this is currently enabled by default
+     */
+    castDurationToTime64?: boolean;
 }
 
 export interface DuckDBFilesystemConfig {

--- a/packages/duckdb-wasm/test/regression/github_470.test.ts
+++ b/packages/duckdb-wasm/test/regression/github_470.test.ts
@@ -1,0 +1,61 @@
+import * as duckdb from '../../src';
+import * as arrow from 'apache-arrow';
+
+// https://github.com/duckdb/duckdb-wasm/issues/470
+export function test470(db: () => duckdb.AsyncDuckDB): void {
+    let conn: duckdb.AsyncDuckDBConnection | null = null;
+    beforeEach(async () => {
+        await db().flushFiles();
+    });
+    afterEach(async () => {
+        if (conn) {
+            await conn.close();
+            conn = null;
+        }
+        await db().flushFiles();
+        await db().dropFiles();
+    });
+    describe('GitHub issues', () => {
+        it('470', async () => {
+
+            // Baseline without cast: we expect an error to be thrown because of the duration type that is emitted
+            await db().open({
+                path: ':memory:',
+                query: {
+                    castDurationToTime64: false,
+                },
+            });
+            conn = await db().connect();
+            conn.query<{
+                interval: arrow.TimeMicrosecond;
+            }>(`SELECT INTERVAL '3' MONTH AS interval`)
+                .then((x) => fail("Query is expected to fail due to duration type not being implemented"))
+                .catch(x => {expect(x).toEqual(new Error("Unrecognized type: \"Duration\" (18)"))});
+
+            // Cast explicitly enabled: Time64 value is returned
+            await db().open({
+                path: ':memory:',
+                query: {
+                    castDurationToTime64: true,
+                },
+            });
+            conn = await db().connect();
+            const resultWithCast = await conn.query<{
+                interval:  arrow.TimeMicrosecond;
+            }>(`SELECT INTERVAL '3' MONTH AS interval`);
+            expect(resultWithCast.toArray()[0].interval?.toString()).toEqual("7776000000000");
+
+            // Cast should be on by default
+            await db().open({
+                path: ':memory:',
+                query: {
+                },
+            });
+            conn = await db().connect();
+            const resultWithDefault = await conn.query<{
+                interval:  arrow.TimeMicrosecond;
+            }>(`SELECT INTERVAL '3' MONTH AS interval`);
+            expect(resultWithDefault.toArray()[0].interval?.toString()).toEqual("7776000000000");
+        });
+    });
+}

--- a/packages/duckdb-wasm/test/regression/index.ts
+++ b/packages/duckdb-wasm/test/regression/index.ts
@@ -3,10 +3,12 @@ import { test332 } from './github_332.test';
 import { test334 } from './github_334.test';
 import { test393 } from './github_393.test';
 import { test448 } from './github_448.test';
+import { test470 } from './github_470.test';
 
 export function testRegressionAsync(adb: () => duckdb.AsyncDuckDB): void {
     test332(adb);
     test334(adb);
     test393(adb);
     test448(adb);
+    test470(adb);
 }


### PR DESCRIPTION
Fixes #470 by adding a castDurationToTime64. Note that its turned on by default and will cast the value emitted by DuckDB from milliseconds to microseconds.