### PR TITLE
Feature/cast decimal to float

### DIFF
--- a/lib/include/duckdb/web/config.h
+++ b/lib/include/duckdb/web/config.h
@@ -44,11 +44,13 @@ struct QueryConfig {
     std::optional<bool> cast_timestamp_to_date = std::nullopt;
     /// Cast Duration to Time64
     std::optional<bool> cast_duration_to_time64 = std::nullopt;
+    /// Cast Decimal to Double
+    std::optional<bool> cast_decimal_to_double = std::nullopt;
 
     /// Has any cast?
     bool hasAnyCast() const {
         return cast_bigint_to_double.value_or(false) || cast_timestamp_to_date.value_or(false) ||
-               cast_duration_to_time64.value_or(false);
+               cast_duration_to_time64.value_or(false) || cast_decimal_to_double.value_or(false);
     }
     /// Read from a document
     static QueryConfig ReadFrom(std::string_view args_json);
@@ -69,6 +71,7 @@ struct WebDBConfig {
         .cast_bigint_to_double = std::nullopt,
         .cast_timestamp_to_date = std::nullopt,
         .cast_duration_to_time64 = std::nullopt,
+        .cast_decimal_to_double = std::nullopt,
     };
     /// The filesystem
     FileSystemConfig filesystem = {

--- a/lib/src/arrow_casts.cc
+++ b/lib/src/arrow_casts.cc
@@ -1,11 +1,10 @@
 #include "duckdb/web/arrow_casts.h"
 
+#include <arrow/array/array_decimal.h>
 #include <arrow/buffer.h>
 #include <arrow/result.h>
 #include <arrow/type_fwd.h>
-
 #include <arrow/util/decimal.h>
-#include <arrow/array/array_decimal.h>
 
 #include <chrono>
 #include <iomanip>
@@ -190,8 +189,8 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> patchRecordBatch(const std::s
                     }
 
                     out = std::make_shared<arrow::DoubleArray>(
-                        array->length(), std::shared_ptr<arrow::Buffer>(buffer.release()),
-                        array->null_bitmap(), array->null_count(), array->offset());
+                        array->length(), std::shared_ptr<arrow::Buffer>(buffer.release()), array->null_bitmap(),
+                        array->null_count(), array->offset());
                 }
                 break;
             }

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -43,6 +43,7 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
                 .cast_bigint_to_double = std::nullopt,
                 .cast_timestamp_to_date = std::nullopt,
                 .cast_duration_to_time64 = true,
+                .cast_decimal_to_double = std::nullopt,
             },
         .filesystem = FileSystemConfig{.allow_full_http_reads = std::nullopt},
     };
@@ -65,6 +66,9 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
             }
             if (q.HasMember("castDurationToTime64") && q["castDurationToTime64"].IsBool()) {
                 config.query.cast_duration_to_time64 = q["castDurationToTime64"].GetBool();
+            }
+            if (q.HasMember("castDecimalToDouble") && q["castDecimalToDouble"].IsBool()) {
+                config.query.cast_decimal_to_double = q["castDecimalToDouble"].GetBool();
             }
         }
         if (doc.HasMember("filesystem") && doc["filesystem"].IsObject()) {

--- a/packages/duckdb-wasm/src/bindings/config.ts
+++ b/packages/duckdb-wasm/src/bindings/config.ts
@@ -12,6 +12,11 @@ export interface DuckDBQueryConfig {
      * Note that this is currently enabled by default
      */
     castDurationToTime64?: boolean;
+    /**
+     * Cast Decimal to Double?
+     * Note that casting decimals to floating point respresentation will have impre
+     */
+    castDecimalToDouble?: boolean;
 }
 
 export interface DuckDBFilesystemConfig {

--- a/packages/duckdb-wasm/test/regression/github_477.test.ts
+++ b/packages/duckdb-wasm/test/regression/github_477.test.ts
@@ -1,0 +1,50 @@
+import * as duckdb from '../../src';
+import * as arrow from 'apache-arrow';
+
+// https://github.com/duckdb/duckdb-wasm/issues/477
+// Note that when ArrowJS supports negative decimals, castDecimalToDouble should probably be deprecated.
+export function test477(db: () => duckdb.AsyncDuckDB): void {
+    let conn: duckdb.AsyncDuckDBConnection | null = null;
+    beforeEach(async () => {
+        await db().flushFiles();
+    });
+    afterEach(async () => {
+        if (conn) {
+            await conn.close();
+            conn = null;
+        }
+        await db().flushFiles();
+        await db().dropFiles();
+    });
+    describe('GitHub issues', () => {
+        it('477', async () => {
+
+            // Baseline without cast: we expect the negative decimal values to not work accurately
+            await db().open({
+                path: ':memory:',
+                query: {
+                },
+            });
+            conn = await db().connect();
+            const resultWithoutCast = await conn.query(`SELECT (-1.9)::DECIMAL(2,1) as decimal`);
+            expect(resultWithoutCast.schema.fields[0].type.scale).toEqual(1);
+            expect(resultWithoutCast.schema.fields[0].type.precision).toEqual(2);
+            // If this assertion breaks, arrow JS was likely updated to handle negative values
+            expect(resultWithoutCast.toArray()[0].decimal.valueOf() == -19).toBe(false);
+
+
+            // Using castDecimalToDouble we force decimals to be cast to doubles, note the inevitable imprecision.
+            await db().open({
+                path: ':memory:',
+                query: {
+                    castDecimalToDouble : true
+                },
+            });
+            conn = await db().connect();
+            const resultWithCast = await conn.query<{
+                decimal: arrow.Float64
+            }>(`SELECT (-1.9)::DECIMAL(2,1) as decimal`);
+            expect(resultWithCast.toArray()[0].decimal?.valueOf()).toEqual(-1.9000000000000001);
+        });
+    });
+}

--- a/packages/duckdb-wasm/test/regression/index.ts
+++ b/packages/duckdb-wasm/test/regression/index.ts
@@ -4,6 +4,7 @@ import { test334 } from './github_334.test';
 import { test393 } from './github_393.test';
 import { test448 } from './github_448.test';
 import { test470 } from './github_470.test';
+import { test477 } from "./github_477.test";
 
 export function testRegressionAsync(adb: () => duckdb.AsyncDuckDB): void {
     test332(adb);
@@ -11,4 +12,5 @@ export function testRegressionAsync(adb: () => duckdb.AsyncDuckDB): void {
     test393(adb);
     test448(adb);
     test470(adb);
+    test477(adb);
 }


### PR DESCRIPTION
The castDecimalToDouble function that be used as a workaround for https://github.com/duckdb/duckdb-wasm/issues/477. 

The included tests should break if the issue is solved in arrowjs so that we know when we can deprecate this.