### PR TITLE
Fix typo in package.json

### DIFF
--- a/packages/duckdb-wasm/package.json
+++ b/packages/duckdb-wasm/package.json
@@ -81,8 +81,8 @@
         "dist",
         "!dist/types/test"
     ],
-    "main:": "dist/duckdb-browser.cjs",
-    "module:": "dist/duckdb-browser.mjs",
+    "main": "dist/duckdb-browser.cjs",
+    "module": "dist/duckdb-browser.mjs",
     "types": "dist/duckdb-browser.d.ts",
     "jsdelivr": "dist/duckdb-browser.cjs",
     "unpkg": "dist/duckdb-browser.mjs",


### PR DESCRIPTION
Fixes #530

fix typo that was blocking `require.resolve()`