### PR TITLE
S3 writes & local s3 test server for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ compile_commands.json
 .vscode
 !.vscode/settings.json
 data/tpch/**/*.parquet
+.idea
+lib/.idea

--- a/lib/include/duckdb/web/io/web_filesystem.h
+++ b/lib/include/duckdb/web/io/web_filesystem.h
@@ -83,9 +83,6 @@ class WebFileSystem : public duckdb::FileSystem {
         /// The extensionOptions at time of opening the http file as buffer
         std::optional<DuckDBConfigOptions> buffered_http_config_options_ = std::nullopt;
 
-
-        // TODO: mark in a clearer way when its a buffered http/s3 file for writing
-
         /// The file stats
         std::shared_ptr<io::FileStatisticsCollector> file_stats_ = nullptr;
 
@@ -282,7 +279,7 @@ class WebFileSystem : public duckdb::FileSystem {
     /// Return the name of the filesytem. Used for forming diagnosis messages.
     std::string GetName() const override;
     /// Write the s3 config to a rapidJSON value
-    static rapidjson::Value writeS3Config(DuckDBConfigOptions& extension_options,
+    static rapidjson::Value writeS3Config(DuckDBConfigOptions &extension_options,
                                           rapidjson::Document::AllocatorType allocator);
 };
 

--- a/lib/include/duckdb/web/io/web_filesystem.h
+++ b/lib/include/duckdb/web/io/web_filesystem.h
@@ -78,9 +78,11 @@ class WebFileSystem : public duckdb::FileSystem {
         /// The data URL (if any)
         std::optional<std::string> data_url_ = std::nullopt;
 
-        // The S3 config at the time of opening. This is only set for HTTP/S3 files that have been transformed to
-        // a Buffer type for writing.
-        std::optional<DuckDBConfigOptions> config_at_open_ = std::nullopt;
+        /// Buffered http file for writing: file is a buffered HTTP/S3 and should be written to data_url_ on closing
+        bool buffered_http_file_ = false;
+        /// The extensionOptions at time of opening the http file as buffer
+        std::optional<DuckDBConfigOptions> buffered_http_config_options_ = std::nullopt;
+
 
         // TODO: mark in a clearer way when its a buffered http/s3 file for writing
 
@@ -280,7 +282,7 @@ class WebFileSystem : public duckdb::FileSystem {
     /// Return the name of the filesytem. Used for forming diagnosis messages.
     std::string GetName() const override;
     /// Write the s3 config to a rapidJSON value
-    static rapidjson::Value writeS3Config(std::shared_ptr<WebDBConfig> config,
+    static rapidjson::Value writeS3Config(DuckDBConfigOptions& extension_options,
                                           rapidjson::Document::AllocatorType allocator);
 };
 

--- a/lib/include/duckdb/web/io/web_filesystem.h
+++ b/lib/include/duckdb/web/io/web_filesystem.h
@@ -78,6 +78,12 @@ class WebFileSystem : public duckdb::FileSystem {
         /// The data URL (if any)
         std::optional<std::string> data_url_ = std::nullopt;
 
+        // The S3 config at the time of opening. This is only set for HTTP/S3 files that have been transformed to
+        // a Buffer type for writing.
+        std::optional<DuckDBConfigOptions> config_at_open_ = std::nullopt;
+
+        // TODO: mark in a clearer way when its a buffered http/s3 file for writing
+
         /// The file stats
         std::shared_ptr<io::FileStatisticsCollector> file_stats_ = nullptr;
 

--- a/lib/js-stubs.js
+++ b/lib/js-stubs.js
@@ -2,8 +2,8 @@ mergeInto(LibraryManager.library, {
     duckdb_web_test_platform_feature: function (feature) {
         return globalThis.DUCKDB_RUNTIME.testPlatformFeature(Module, feature);
     },
-    duckdb_web_fs_file_open: function (fileId) {
-        return globalThis.DUCKDB_RUNTIME.openFile(Module, fileId);
+    duckdb_web_fs_file_open: function (fileId, flags) {
+        return globalThis.DUCKDB_RUNTIME.openFile(Module, fileId, flags);
     },
     duckdb_web_fs_file_sync: function (fileId) {
         return globalThis.DUCKDB_RUNTIME.syncFile(Module, fileId);

--- a/lib/src/io/web_filesystem.cc
+++ b/lib/src/io/web_filesystem.cc
@@ -265,12 +265,10 @@ void WebFileSystem::WebFileHandle::Close() {
                 std::string msg = std::string{"Failed to write file: "} + file.file_name_;
                 throw std::runtime_error(msg);
             }
+        } else {
+            return;
         }
-        return;
     }
-
-    // TODO maybe this code also applies to me?
-
     // Close the file in the runtime
     fs_guard.unlock();
     duckdb_web_fs_file_close(file.file_id_);

--- a/packages/duckdb-wasm/karma/karma.base.cjs
+++ b/packages/duckdb-wasm/karma/karma.base.cjs
@@ -15,8 +15,13 @@ module.exports = function (config) {
             'karma-spec-reporter',
             'karma-coverage',
             'karma-jasmine-html-reporter',
+            require('./s3rver/s3rver')
         ],
-        frameworks: ['jasmine'],
+        frameworks: ['jasmine', 's3rver'],
+        s3rver: {
+            port: 4923,
+            silent: true
+        },
         files: [
             { pattern: 'packages/duckdb-wasm/dist/tests-browser.js' },
             { pattern: 'packages/duckdb-wasm/dist/*.wasm', included: false, watched: false, served: true },

--- a/packages/duckdb-wasm/karma/s3rver/s3rver.js
+++ b/packages/duckdb-wasm/karma/s3rver/s3rver.js
@@ -1,0 +1,27 @@
+const S3rver = require('s3rver');
+
+const CORS_CONFIG = "<CORSConfiguration>\n" +
+    "  <CORSRule>\n" +
+    "    <AllowedOrigin>*</AllowedOrigin>\n" +
+    "    <AllowedMethod>PUT</AllowedMethod>\n" +
+    "    <AllowedMethod>GET</AllowedMethod>\n" +
+    "    <AllowedMethod>HEAD</AllowedMethod>\n" +
+    "    <AllowedHeader>*</AllowedHeader>\n" +
+    "  </CORSRule>\n" +
+    "</CORSConfiguration>";
+
+var createS3rver = function (args, config, logger) {
+    const log = logger.create('S3-test-server');
+    log.info('Starting S3 test server on port ' + config.s3rver.port);
+    let instance = new S3rver({
+        port: config.s3rver.port,
+        address: 'localhost',
+        silent: config.s3rver.silent,
+        directory: './../../.tmp/s3rver',
+        configureBuckets: [{name: 'test-bucket', configs:[CORS_CONFIG]}]
+    }).run();
+};
+
+module.exports = {
+    'framework:s3rver': ['factory', createS3rver]
+};

--- a/packages/duckdb-wasm/package.json
+++ b/packages/duckdb-wasm/package.json
@@ -54,6 +54,7 @@
         "prettier": "^2.5.1",
         "puppeteer": "^13.1.1",
         "rimraf": "^3.0.2",
+        "s3rver": "^3.7.1",
         "typedoc": "^0.22.11",
         "typescript": "^4.5.4"
     },

--- a/packages/duckdb-wasm/src/bindings/runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime.ts
@@ -41,6 +41,22 @@ export enum DuckDBDataProtocol {
     S3 = 4,
 }
 
+/** File flags for opening files*/
+export enum FileFlags {
+    //! Open file with read access
+    FILE_FLAGS_READ = 1 << 0,
+    //! Open file with write access
+    FILE_FLAGS_WRITE = 1 << 1,
+    //! Use direct IO when reading/writing to the file
+    FILE_FLAGS_DIRECT_IO = 1 << 2,
+    //! Create file if not exists, can only be used together with WRITE
+    FILE_FLAGS_FILE_CREATE = 1 << 3,
+    //! Always create a new file. If a file exists, the file is truncated. Cannot be used together with CREATE.
+    FILE_FLAGS_FILE_CREATE_NEW = 1 << 4,
+    //! Open file in append mode
+    FILE_FLAGS_APPEND = 1 << 5,
+}
+
 /** Configuration for the AWS S3 Filesystem */
 export interface S3Config {
     region?: string;
@@ -110,7 +126,7 @@ export interface DuckDBRuntime {
     testPlatformFeature(mod: DuckDBModule, feature: number): boolean;
 
     // File APIs with dedicated file identifier
-    openFile(mod: DuckDBModule, fileId: number): void;
+    openFile(mod: DuckDBModule, fileId: number, flags: FileFlags): void;
     syncFile(mod: DuckDBModule, fileId: number): void;
     closeFile(mod: DuckDBModule, fileId: number): void;
     getLastFileModificationTime(mod: DuckDBModule, fileId: number): number;
@@ -136,7 +152,7 @@ export const DEFAULT_RUNTIME: DuckDBRuntime = {
     _udfFunctions: new Map(),
 
     testPlatformFeature: (_mod: DuckDBModule, _feature: number): boolean => false,
-    openFile: (_mod: DuckDBModule, _fileId: number): void => {},
+    openFile: (_mod: DuckDBModule, _fileId: number, flags: FileFlags): void => {},
     syncFile: (_mod: DuckDBModule, _fileId: number): void => {},
     closeFile: (_mod: DuckDBModule, _fileId: number): void => {},
     getLastFileModificationTime: (_mod: DuckDBModule, _fileId: number): number => {

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -373,8 +373,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                 const buffer = mod.HEAPU8.subarray(buf, buf + bytes);
                 const xhr = new XMLHttpRequest();
                 xhr.open('PUT', getHTTPUrl(file?.s3Config, file.dataUrl!), false);
-                // TODO do we really need the content-type?
-                addS3Headers(xhr, file?.s3Config, file.dataUrl!, 'PUT', 'text/data;charset=utf-8', buffer);
+                addS3Headers(xhr, file?.s3Config, file.dataUrl!, 'PUT', '', buffer);
                 xhr.send(buffer);
                 return bytes;
             }

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -1,5 +1,5 @@
-import { StatusCode } from '../status';
-import { addS3Headers, getHTTPUrl} from '../utils'
+import {StatusCode} from '../status';
+import {addS3Headers, getHTTPUrl} from '../utils'
 
 import {
     callSRet,
@@ -84,47 +84,46 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         }
     },
 
-    // TODO add: forceFullHTTP: boolean
-    // TODO open specifically for writing?
-    //   - if 403 we can't write
-    //   - if 404 we can create
-    //   - if 2xx we overwrite
     openFile: (mod: DuckDBModule, fileId: number, flags: FileFlags): number => {
         try {
             BROWSER_RUNTIME._fileInfoCache.delete(fileId);
             const file = BROWSER_RUNTIME.getFileInfo(mod, fileId);
-            console.log("open with flag (" + flags + "): " + JSON.stringify(file));
-
-            if (flags & FileFlags.FILE_FLAGS_READ && flags & FileFlags.FILE_FLAGS_WRITE) {
-                const err = "Opening a file for both reading and writing not implemented";
-                console.log(err);
-                failWith(mod, err);
-                return 0;
-            } else if (!(flags & FileFlags.FILE_FLAGS_READ) && !(flags & FileFlags.FILE_FLAGS_WRITE)) {
-                const err = "File opened without read or write";
-                console.log(err);
-                failWith(mod, err);
-                return 0;
-            } else if (flags & FileFlags.FILE_FLAGS_WRITE) {
-                // TODO check if file exists and check the exists and overwrite flags?
-                // Follow regular buffer creation from reading but with empty buffer
-                // TODO clean up
-                // TODO 0 may not work: below 1 is used for now similarly to below
-                // TODO what if truncate is not set and empty file is written?
-                const data = mod._malloc(1);
-                const src = new Uint8Array();
-                mod.HEAPU8.set(src, data);
-                const result = mod._malloc(2 * 8);
-                mod.HEAPF64[(result >> 3) + 0] = 1;
-                mod.HEAPF64[(result >> 3) + 1] = data;
-                return result;
-            }
-
-            // Proceed as normal for reading
             switch (file?.dataProtocol) {
-                // HTTP File
                 case DuckDBDataProtocol.HTTP:
                 case DuckDBDataProtocol.S3: {
+                    if (flags & FileFlags.FILE_FLAGS_READ && flags & FileFlags.FILE_FLAGS_WRITE) {
+                        throw new Error(`Opening file ${file.fileName} failed: cannot open file with both read and write flags set`);
+                    } else if (flags & FileFlags.FILE_FLAGS_APPEND){
+                        throw new Error(`Opening file ${file.fileName} failed: appending to HTTP/S3 files is not supported`);
+                    } else if (flags & FileFlags.FILE_FLAGS_WRITE) {
+                        // We send a HEAD request to try to determine if we can write to data_url
+                        const xhr = new XMLHttpRequest();
+                        if (file.dataProtocol == DuckDBDataProtocol.S3) {
+                            xhr.open('HEAD', getHTTPUrl(file.s3Config, file.dataUrl!), false);
+                            addS3Headers(xhr, file.s3Config, file.dataUrl!, 'HEAD');
+                        } else {
+                            xhr.open('HEAD', file.dataUrl!, false);
+                        }
+                        xhr.send(null);
+
+                        // Expect 200 for existing files that we will overwrite or 404 for non-existent files can be created
+                        if (xhr.status != 200 && xhr.status != 404) {
+                            throw new Error(`Opening file ${file.fileName} failed: Unexpected return status from server (${xhr.status})`);
+                        } else if (xhr.status == 404 &&!(flags & FileFlags.FILE_FLAGS_FILE_CREATE || flags & FileFlags.FILE_FLAGS_FILE_CREATE_NEW)) {
+                            throw new Error(`Opening file ${file.fileName} failed: Cannot write to non-existent file without FILE_FLAGS_FILE_CREATE or FILE_FLAGS_FILE_CREATE_NEW flag.`);
+                        }
+                        // Return an empty buffer that can be used to buffer the writes to this s3/http file
+                        const data = mod._malloc(1);
+                        const src = new Uint8Array();
+                        mod.HEAPU8.set(src, data);
+                        const result = mod._malloc(2 * 8);
+                        mod.HEAPF64[(result >> 3) + 0] = 1;
+                        mod.HEAPF64[(result >> 3) + 1] = data;
+                        return result;
+                    } else if (flags != FileFlags.FILE_FLAGS_READ) {
+                        throw new Error(`Opening file ${file.fileName} failed: unsupported file flags: ${flags}`);
+                    }
+
                     // Supports ranges?
                     let error: any | null = null;
                     try {
@@ -214,7 +213,6 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
     glob: (mod: DuckDBModule, pathPtr: number, pathLen: number) => {
         try {
             const path = readString(mod, pathPtr, pathLen);
-
             // Starts with http?
             // Try a HTTP HEAD request
             if (path.startsWith('http') || path.startsWith('s3://')) {
@@ -242,7 +240,6 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
     checkFile: (mod: DuckDBModule, pathPtr: number, pathLen: number): boolean => {
         try {
             const path = readString(mod, pathPtr, pathLen);
-
             // Starts with http or S3?
             // Try a HTTP HEAD request
             if (path.startsWith('http') || path.startsWith('s3://')) {
@@ -368,7 +365,6 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
     },
     writeFile: (mod: DuckDBModule, fileId: number, buf: number, bytes: number, location: number) => {
         const file = BROWSER_RUNTIME.getFileInfo(mod, fileId);
-        console.log("trying write: " + JSON.stringify(file));
         switch (file?.dataProtocol) {
             case DuckDBDataProtocol.HTTP:
                 failWith(mod, 'Cannot write to HTTP file');

--- a/packages/duckdb-wasm/src/bindings/runtime_node.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_node.ts
@@ -7,7 +7,7 @@ import {
     failWith,
     readString,
     decodeText,
-    DuckDBDataProtocol,
+    DuckDBDataProtocol, FileFlags,
 } from './runtime';
 import { StatusCode } from '../status';
 import { DuckDBModule } from './duckdb_module';
@@ -56,7 +56,7 @@ export const NODE_RUNTIME: DuckDBRuntime & {
         }
     },
 
-    openFile(mod: DuckDBModule, fileId: number): number {
+    openFile(mod: DuckDBModule, fileId: number, flags: FileFlags): number {
         try {
             NODE_RUNTIME._fileInfoCache.delete(fileId);
             const file = NODE_RUNTIME.resolveFileInfo(mod, fileId);

--- a/packages/duckdb-wasm/src/utils/s3_helper.ts
+++ b/packages/duckdb-wasm/src/utils/s3_helper.ts
@@ -15,7 +15,7 @@ export interface S3Params {
     datetimeNow: string
 }
 
-interface S3PayloadParams {
+export interface S3PayloadParams {
     contentHash: string | null,
     contentType: string | null
 }
@@ -175,7 +175,16 @@ export function parseS3Url (url: string) : {bucket : string, path : string} {
 
 export function getHTTPUrl(config : S3Config | undefined, url : string) : string {
     const parsedUrl = parseS3Url(url);
-    const host = parsedUrl.bucket + "." + (config?.endpoint ? config?.endpoint : "s3.amazonaws.com");
-    const httpHost = "https://" + host;
+    let httpHost;
+
+    if (config?.endpoint?.startsWith("http")) {
+        // Endpoint is a full url, we append the bucket
+        httpHost = `${config?.endpoint}/${parsedUrl.bucket}`;
+    } else if (config?.endpoint) {
+        // Endpoint is not a full url and the https://{bucket}.{domain} format will be used
+        httpHost = `https://${parsedUrl.bucket}.${config?.endpoint}`;
+    } else {
+        httpHost = `https://${parsedUrl.bucket}.s3.amazonaws.com`;
+    }
     return httpHost + parsedUrl.path;
 }

--- a/packages/duckdb-wasm/test/httpfs_test.ts
+++ b/packages/duckdb-wasm/test/httpfs_test.ts
@@ -46,11 +46,12 @@ export function testHTTPFS(adb: () => duckdb.AsyncDuckDB, sdb: () => duckdb.Duck
     let test_data_small: Uint8Array | null;
     let test_data_large: Uint8Array | null;
 
-    // PUTS an S3 file to the S3 test server
+    // PUTs an S3 file to the S3 test server
     const putTestFileToS3 = async function (fileName : string, format: string, test_data : Uint8Array | null) {
-        const bucket_name = BUCKET_NAME;
         await adb().registerFileBuffer('test_file.parquet', test_data!);
-        const conn_async = await adb().connect();
+        if (!conn_async) {
+            conn_async = await adb().connect();
+        }
         await setAwsConfig(conn_async, AWSConfigType.VALID);
 
         await conn_async.send(`CREATE TABLE test_table AS (SELECT * FROM parquet_scan('test_file.parquet'));`);

--- a/packages/duckdb-wasm/test/httpfs_test.ts
+++ b/packages/duckdb-wasm/test/httpfs_test.ts
@@ -1,73 +1,19 @@
 import * as duckdb from '../src/';
-import {S3Params, createS3Headers, uriEncode} from '../src/utils'
+import {S3Params, S3PayloadParams, createS3Headers, uriEncode, getHTTPUrl} from '../src/utils'
 import {AsyncDuckDBConnection, DuckDBBindings, DuckDBBindingsBase, DuckDBModule} from "../src/";
 import BROWSER_RUNTIME from "../src/bindings/runtime_browser";
 
-// this computes the signature from https://czak.pl/2015/09/15/s3-rest-api-with-curl.html
-const verifyS3Helper = function () {
-    const testParams1 : S3Params = {
-        url: "/",
-        query: "",
-        host: "my-precious-bucket.s3.amazonaws.com",
-        region: "us-east-1",
-        service: "s3",
-        method: "GET",
-        accessKeyId: "AKIAIOSFODNN7EXAMPLE",
-        secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-        sessionToken: "",
-        dateNow: "20150915",
-        datetimeNow: "20150915T124500Z",
-    };
-
-    const test_header = createS3Headers(testParams1);
-    if (test_header.get("Authorization") != "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20150915/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=182072eb53d85c36b2d791a1fa46a12d23454ec1e921b02075c23aee40166d5a") {
-        throw new Error("Auth header incorrect");
-    }
-
-    const canonical_query_string = "delimiter=%2F&encoding-type=url&list-type=2&prefix="; // aws s3 ls <bucket>
-
-    const testParams2 : S3Params = {
-        url: "/",
-        query: canonical_query_string,
-        host: "my-precious-bucket.s3.eu-west-1.amazonaws.com",
-        region: "eu-west-1",
-        service: "s3",
-        method: "GET",
-        accessKeyId: "ASIAYSPIOYDTHTBIITVC",
-        secretAccessKey: "vs1BZPxSL2qVARBSg5vCMKJsavCoEPlo/HSHRaVe",
-        sessionToken: "IQoJb3JpZ2luX2VjENX//////////wEaCWV1LXdlc3QtMSJHMEUCIQDfjzs9BYHrEXDMU/NR+PHV1uSTr7CSVSQdjKSfiPRLdgIgCCztF0VMbi9+uHHAfBVKhV4t9MlUrQg3VAOIsLxrWyoqlAIIHRAAGgw1ODk0MzQ4OTY2MTQiDOGl2DsYxENcKCbh+irxARe91faI+hwUhT60sMGRFg0GWefKnPclH4uRFzczrDOcJlAAaQRJ7KOsT8BrJlrY1jSgjkO7PkVjPp92vi6lJX77bg99MkUTJActiOKmd84XvAE5bFc/jFbqechtBjXzopAPkKsGuaqAhCenXnFt6cwq+LZikv/NJGVw7TRphLV+Aq9PSL9XwdzIgsW2qXwe1c3rxDNj53yStRZHVggdxJ0OgHx5v040c98gFphzSULHyg0OY6wmCMTYcswpb4kO2IIi6AiD9cY25TlwPKRKPi5CdBsTPnyTeW62u7PvwK0fTSy4ZuJUuGKQnH2cKmCXquEwoOHEiQY6nQH9fzY/EDGHMRxWWhxu0HiqIfsuFqC7GS0p0ToKQE+pzNsvVwMjZc+KILIDDQpdCWRIwu53I5PZy2Cvk+3y4XLvdZKQCsAKqeOc4c94UAS4NmUT7mCDOuRV0cLBVM8F0JYBGrUxyI+YoIvHhQWmnRLuKgTb5PkF7ZWrXBHFWG5/tZDOvBbbaCWTlRCL9b0Vpg5+BM/81xd8jChP4w83",
-        dateNow: "20210904",
-        datetimeNow: "20210904T121746Z",
-    };
-    const test_header2 = createS3Headers(testParams2);
-
-    if (test_header2.get("Authorization") !=
-        "AWS4-HMAC-SHA256 Credential=ASIAYSPIOYDTHTBIITVC/20210904/eu-west-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=4d9d6b59d7836b6485f6ad822de97be40287da30347d83042ea7fbed530dc4c0") {
-        console.log(test_header2.get("Authorization"));
-        console.log("AWS4-HMAC-SHA256 Credential=ASIAYSPIOYDTHTBIITVC/20210904/eu-west-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=4d9d6b59d7836b6485f6ad822de97be40287da30347d83042ea7fbed530dc4c0");
-        throw new Error("test_header2 incorrect");
-    }
-
-    if (uriEncode("/category=Books/") != "/category%3DBooks/") {
-        console.log(uriEncode("/category=Books/"));
-        throw new Error("test fail1");
-    }
-    if (uriEncode("/?category=Books&title=Ducks Retreat/") != "/%3Fcategory%3DBooks%26title%3DDucks%20Retreat/") {
-        throw new Error("test fail2");
-    }
-
-    if (uriEncode("/?category=Books&title=Ducks Retreat/", true) !=
-        "%2F%3Fcategory%3DBooks%26title%3DDucks%20Retreat%2F") {
-        throw new Error("test fail3");
-    }
-}
+// S3 config for tests
+const BUCKET_NAME       = 'test-bucket';
+const ACCESS_KEY_ID     = 'S3RVER';
+const ACCESS_KEY_SECRET = 'S3RVER';
+const S3_ENDPOINT       = 'http://localhost:4923';
 
 enum AWSConfigType {
     EMPTY,
     VALID,
     INVALID
 }
-
 const setAwsConfig = async function (conn : AsyncDuckDBConnection, type : AWSConfigType = AWSConfigType.VALID) {
     switch(type) {
         case AWSConfigType.EMPTY:
@@ -75,18 +21,21 @@ const setAwsConfig = async function (conn : AsyncDuckDBConnection, type : AWSCon
             await conn.query("SET s3_access_key_id='';");
             await conn.query("SET s3_secret_access_key='';");
             await conn.query("SET s3_session_token='';");
+            await conn.query(`SET s3_endpoint='${S3_ENDPOINT}';`);
             break;
         case AWSConfigType.VALID:
-            await conn.query("SET s3_region='nope';");
-            await conn.query("SET s3_access_key_id='nope';");
-            await conn.query("SET s3_secret_access_key='nope';");
+            await conn.query("SET s3_region='eu-west-1';");
+            await conn.query(`SET s3_access_key_id='${ACCESS_KEY_ID}';`);
+            await conn.query(`SET s3_secret_access_key='${ACCESS_KEY_SECRET}';`);
             await conn.query("SET s3_session_token='';");
+            await conn.query(`SET s3_endpoint='${S3_ENDPOINT}';`);
             break;
         case AWSConfigType.INVALID:
             await conn.query("SET s3_region='a-very-remote-and-non-existent-s3-region';");
             await conn.query("SET s3_access_key_id='THISACCESSKEYIDISNOTVALID';");
             await conn.query("SET s3_secret_access_key='THISSECRETACCESSKEYISNOTVALID';");
             await conn.query("SET s3_session_token='INVALIDSESSIONTOKEN';");
+            await conn.query(`SET s3_endpoint='${S3_ENDPOINT}';`);
             break;
     }
 }
@@ -94,55 +43,74 @@ const setAwsConfig = async function (conn : AsyncDuckDBConnection, type : AWSCon
 export function testHTTPFS(adb: () => duckdb.AsyncDuckDB, sdb: () => duckdb.DuckDBBindings, resolveData: (url: string) => Promise<Uint8Array | null>,  baseDir: string): void {
     let conn_async: duckdb.AsyncDuckDBConnection | null;
     let conn_sync: duckdb.DuckDBConnection | null;
+    let test_data_small: Uint8Array | null;
+    let test_data_large: Uint8Array | null;
 
-    beforeEach(async () => {
+    // PUTS an S3 file to the S3 test server
+    const putTestFileToS3 = async function (fileName : string, format: string, test_data : Uint8Array | null) {
+        const bucket_name = BUCKET_NAME;
+        await adb().registerFileBuffer('test_file.parquet', test_data!);
+        const conn_async = await adb().connect();
+        await setAwsConfig(conn_async, AWSConfigType.VALID);
+
+        await conn_async.send(`CREATE TABLE test_table AS (SELECT * FROM parquet_scan('test_file.parquet'));`);
+        await conn_async.query(`COPY test_table TO 's3://${BUCKET_NAME}/${fileName}.${format}' (FORMAT '${format}');`);
+
+        await adb().flushFiles();
+        await adb().dropFiles();
+    }
+
+    // Requires an open conn_async
+    const assertTestFileResultCorrect = async function (result: any, test_data : Uint8Array | null ) {
+        await adb().registerFileBuffer('test_file_baseline.parquet', test_data!);
+        const result_baseline = await conn_async!.query(`SELECT * FROM parquet_scan('test_file_baseline.parquet');`);
+        expect(result.getColumnAt(0).toArray()).toEqual(result_baseline.getColumnAt(0)?.toArray());
+    }
+
+    const getModule = function () {
+        if (!conn_sync) {
+            conn_sync = sdb().connect();
+        }
+        let module : DuckDBModule | null = null;
+        conn_sync!.useUnsafe((bindings: DuckDBBindings, con_number: number) => {
+            module = (bindings as DuckDBBindingsBase).mod;
+        });
+        expect(module).toBeDefined();
+        return module;
+    }
+
+    beforeAll(async () => {
+        test_data_small = await resolveData('/uni/studenten.parquet');
+        test_data_large = await resolveData('/tpch/0_01/parquet/lineitem.parquet');
     });
     afterEach(async () => {
         if (conn_async) {
+            adb().flushFiles();
+            adb().dropFiles();
             await conn_async.close();
             conn_async = null;
         }
         if (conn_sync) {
+            sdb().flushFiles();
+            sdb().dropFiles();
             conn_sync.close();
             conn_sync = null;
         }
-
     });
     describe('HTTPFS', () => {
-        it('s3 helper passes validation', () => {
-            expect(() => verifyS3Helper()).not.toThrow();
-        });
-
-        it('can fetch regular https file', async () => {
+        it('can fetch https file', async () => {
+            await adb().reset();
             conn_async = await adb().connect();
-            const results = await conn_async.query("select * from \"https://raw.githubusercontent.com/duckdb/duckdb-wasm/master/data/test.csv\";");
+            const results = await conn_async.query(`select * from "https://raw.githubusercontent.com/duckdb/duckdb-wasm/master/data/test.csv";`);
             expect(results.getColumnAt(2)?.get(2)).toEqual(9);
         });
 
-        it('can query s3 urls without authentication', async () => {
-            conn_async = await adb().connect();
-            setAwsConfig(conn_async, AWSConfigType.EMPTY);
-
-            // Test s3 code by settings the config such that it translates to a raw.githubusercontent url
-            await conn_async.query("SET s3_endpoint='githubusercontent.com';");
-
-            // Url should translate to https://raw.githubusercontent.com/duckdb/duckdb-wasm/master/data/test.csv
-            // Note that this will use the fallback full http request instead of the range request due to github not
-            // supporting range header on CORS
-            const result = await conn_async.query("select * from \"s3://raw/duckdb/duckdb-wasm/master/data/test.csv\";");
-            expect(result.getColumnAt(2)?.get(2)).toEqual(9);
-        });
-
         it('s3 config is set correctly', () => {
-            // Set up a Runtime for testing and get the module of the current bindings
             sdb().reset();
             conn_sync = sdb().connect();
-            let module : DuckDBModule | null = null;
-            conn_sync!.useUnsafe((bindings: DuckDBBindings, con_number: number) => {
-                module = (bindings as DuckDBBindingsBase).mod;
-            });
-            expect(module).toBeDefined();
+            const module = getModule();
 
+            // Default values are empty
             const globalFileInfo = BROWSER_RUNTIME.getGlobalFileInfo(module!);
             const cacheEpoch = globalFileInfo!.cacheEpoch;
             expect(globalFileInfo?.s3Config).toBeDefined();
@@ -157,7 +125,6 @@ export function testHTTPFS(adb: () => duckdb.AsyncDuckDB, sdb: () => duckdb.Duck
             conn_sync.query("SET s3_secret_access_key='THISSECRETACCESSKEYISNOTVALID';");
             conn_sync.query("SET s3_session_token='ANICESESSIONTOKEN';");
             conn_sync.query("SET s3_endpoint='localhost:1337';");
-
             const globalFileInfoUpdated = BROWSER_RUNTIME.getGlobalFileInfo(module!);
             expect(globalFileInfoUpdated?.s3Config).toBeDefined();
             expect(globalFileInfoUpdated?.s3Config?.region).toEqual("a-very-remote-and-non-existent-s3-region");
@@ -166,130 +133,158 @@ export function testHTTPFS(adb: () => duckdb.AsyncDuckDB, sdb: () => duckdb.Duck
             expect(globalFileInfoUpdated?.s3Config?.sessionToken).toEqual("ANICESESSIONTOKEN");
             expect(globalFileInfoUpdated?.s3Config?.endpoint).toEqual("localhost:1337");
             expect(globalFileInfoUpdated?.cacheEpoch).toEqual(cacheEpoch+5);
-        });
 
-        it('resetting the database clears the config state', async () => {
-            // Set up a Runtime for testing and get the module of the current bindings
-            sdb().reset();
-            conn_sync = sdb().connect();
-            let module : DuckDBModule | null = null;
-            conn_sync.useUnsafe((bindings: DuckDBBindings, con_number: number) => {
-                module = (bindings as DuckDBBindingsBase).mod;
-            });
-            expect(module).toBeDefined();
-
-            conn_sync.query("SET s3_region='a-very-remote-and-non-existent-s3-region';");
-
-            const globalFileInfo = BROWSER_RUNTIME.getGlobalFileInfo(module!);
-            expect(globalFileInfo?.s3Config).toBeDefined();
-            expect(globalFileInfo?.s3Config?.region).toEqual("a-very-remote-and-non-existent-s3-region");
-
+            // Reset should clear config
             conn_sync.close();
             sdb().reset();
-
             conn_sync = sdb().connect();
-
-            // region should be reset as well
-            const globalFileInfoUpdated = BROWSER_RUNTIME.getGlobalFileInfo(module!);
-            expect(globalFileInfoUpdated?.s3Config).toBeDefined();
-            expect(globalFileInfoUpdated?.s3Config?.region).toEqual("");
+            const globalFileInfoAfterReset = BROWSER_RUNTIME.getGlobalFileInfo(module!);
+            expect(globalFileInfoAfterReset?.s3Config).toBeDefined();
+            expect(globalFileInfoAfterReset?.s3Config?.region).toEqual("");
+            expect(globalFileInfoAfterReset?.s3Config?.accessKeyId).toEqual("");
+            expect(globalFileInfoAfterReset?.s3Config?.secretAccessKey).toEqual("");
+            expect(globalFileInfoAfterReset?.s3Config?.sessionToken).toEqual("");
+            expect(globalFileInfoAfterReset?.s3Config?.endpoint).toEqual("");
         });
 
-        // TODO: find a way to run these tests in CI
-        // it('can fetch s3 file with correct auth credentials', async () => {
-        //     conn_async = await adb().connect();
-        //     await setAwsConfig(conn_async, AWSConfigType.VALID);
-        //
-        //     const results_with_auth = await conn_async.query("select * from \"s3://test-bucket-ceiveran/test.csv\";");
-        //     expect(results_with_auth.getColumnAt(2)?.get(2)).toEqual(9);
-        // });
-        //
-        // // 0_lineitem.parquet should be sufficiently big to ensure the 2nd query will request an uncached part of 0_lineitem.parquet
-        // it('properly invalidates caches on settings update.', async () => {
-        //     await adb().reset();
-        //     conn_async = await adb().connect();
-        //
-        //     // Query first part of file, this should only partially read the file, right?
-        //     const results_with_auth = await conn_async.query("select l_partkey from \"s3://test-bucket-ceiveran/0_lineitem.parquet\" limit 1;");
-        //     expect(results_with_auth.getColumnAt(0)?.get(0)).toEqual(15519);
-        //
-        //     await setAwsConfig(conn_async, AWSConfigType.INVALID);
-        //
-        //     // query touching the whole table should now fail
-        //     await expectAsync(conn_async!.query("select avg(l_partkey) from \"s3://test-bucket-ceiveran/0_lineitem.parquet\";"))
-        //         .toBeRejected();
-        // });
-        // it('can write small csv file to s3', async () => {
-        //     conn_async = await adb().connect();
-        //     await setAwsConfig(conn_async);
-        //
-        //     // write the file for the first time
-        //     await conn_async.query("COPY (SELECT * FROM range(1000,1010) tbl(i)) TO 's3://test-bucket-ceiveran/test_written.csv' (FORMAT 'csv');");
-        //
-        //     // confirm file matches
-        //     const result = await conn_async.query("SELECT * FROM \"s3://test-bucket-ceiveran/test_written.csv\";");
-        //     expect(result.getColumnAt(0)?.get(6)).toEqual(1006);
-        //
-        //     await adb().flushFiles();
-        //     await adb().dropFiles();
-        //
-        //     // write the file for the second time
-        //     await conn_async.query("COPY (SELECT * FROM range(2000,2010) tbl(i)) TO 's3://test-bucket-ceiveran/test_written.csv' (FORMAT 'csv');");
-        //
-        //     // file should be rewritten to new value now
-        //     const result2 = await conn_async.query("SELECT * FROM \"s3://test-bucket-ceiveran/test_written.csv\";");
-        //     expect(result2.getColumnAt(0)?.get(6)).toEqual(2006);
-        // });
-        // it('write after read throws incorrect flag error without dropping files', async () => {
-        //     conn_async = await adb().connect();
-        //     await setAwsConfig(conn_async);
-        //
-        //     // write the file for the first time
-        //     await conn_async.query("COPY (SELECT * FROM range(1000,1010) tbl(i)) TO 's3://test-bucket-ceiveran/test_written.csv' (FORMAT 'csv');");
-        //
-        //     // confirm file matches
-        //     const result = await conn_async.query("SELECT * FROM \"s3://test-bucket-ceiveran/test_written.csv\";");
-        //     expect(result.getColumnAt(0)?.get(6)).toEqual(1006);
-        //
-        //     // write the file for the second time should fail: the read flag will not be set on this file
-        //     await expectAsync(conn_async!.query("COPY (SELECT * FROM range(2000,2010) tbl(i)) TO 's3://test-bucket-ceiveran/test_written.csv' (FORMAT 'csv');"))
-        //         .toBeRejectedWithError("File is not opened in write mode");
-        // });
-        // it('can write small parquet file to S3', async () => {
-        //     conn_async = await adb().connect();
-        //     const students = await resolveData('/uni/studenten.parquet');
-        //     expect(students).not.toBeNull();
-        //     await adb().registerFileBuffer('studenten.parquet', students!);
-        //
-        //     // Create table from local parquet file
-        //     await conn_async.send(`CREATE TABLE studenten AS (SELECT * FROM parquet_scan('studenten.parquet'));`);
-        //
-        //     // Export to S3
-        //     await setAwsConfig(conn_async);
-        //     await conn_async.query("COPY studenten TO 's3://test-bucket-ceiveran/studenten.parquet' (FORMAT 'parquet');");
-        //
-        //     const result_s3 = await conn_async.query("SELECT * FROM \"s3://test-bucket-ceiveran/studenten.parquet\";");
-        //     const result_local = await conn_async.query("SELECT * FROM studenten;");
-        //     expect(result_s3.getColumnAt(0)?.toArray()).toEqual(result_local.getColumnAt(0)?.toArray());
-        // });
-        //
-        // it('can write medium sized(34MB) parquet file to S3', async () => {
-        //     conn_async = await adb().connect();
-        //     const lineitem = await resolveData('/tpch/0_1/parquet/lineitem.parquet');
-        //     expect(lineitem).not.toBeNull();
-        //     await adb().registerFileBuffer('lineitem.parquet', lineitem!);
-        //
-        //     // Create table from local parquet file
-        //     await conn_async.send(`CREATE TABLE lineitem AS (SELECT * FROM parquet_scan('lineitem.parquet'));`);
-        //
-        //     // Export to S3
-        //     await setAwsConfig(conn_async);
-        //     await conn_async.query("COPY lineitem TO 's3://test-bucket-ceiveran/lineitem.parquet' (FORMAT 'parquet');");
-        //
-        //     // Compare results
-        //     const result_s3 = await conn_async.query("SELECT avg(l_extendedprice) FROM \"s3://test-bucket-ceiveran/lineitem.parquet\";");
-        //     const result_local = await conn_async.query("SELECT avg(l_extendedprice) FROM lineitem;");
-        //     expect(result_s3.getColumnAt(0)?.get(0)).toEqual(result_local.getColumnAt(0)?.get(0));
-        // });
+        it('url parsing is correct', () => {
+            conn_sync = sdb().connect();
+            const module = getModule();
+
+            conn_sync.query("SET s3_endpoint='';");
+            const globalFileInfoDefault = BROWSER_RUNTIME.getGlobalFileInfo(module!);
+            expect(globalFileInfoDefault?.s3Config).toBeDefined();
+            const defaultUrl = getHTTPUrl(globalFileInfoDefault?.s3Config, `s3://${BUCKET_NAME}/test-file.csv`);
+            expect(defaultUrl).toEqual(`https://${BUCKET_NAME}.s3.amazonaws.com/test-file.csv`);
+
+            conn_sync.query("SET s3_endpoint='https://duckdblabs.com';");
+            const globalFileInfoFullUrl = BROWSER_RUNTIME.getGlobalFileInfo(module!);
+            expect(globalFileInfoFullUrl?.s3Config).toBeDefined();
+            const fullUrl = getHTTPUrl(globalFileInfoFullUrl?.s3Config, `s3://${BUCKET_NAME}/test-file.csv`);
+            expect(fullUrl).toEqual(`https://duckdblabs.com/${BUCKET_NAME}/test-file.csv`);
+
+            conn_sync.query("SET s3_endpoint='duckdblabs.com';");
+            const globalFileInfoDomain = BROWSER_RUNTIME.getGlobalFileInfo(module!);
+            expect(globalFileInfoDomain?.s3Config).toBeDefined();
+            const domainOnlyUrl = getHTTPUrl(globalFileInfoDomain?.s3Config, `s3://${BUCKET_NAME}/test-file.csv`);
+            expect(domainOnlyUrl).toEqual(`https://${BUCKET_NAME}.duckdblabs.com/test-file.csv`);
+        });
+
+        it('can read and write csv file from S3 with correct auth credentials', async () => {
+            conn_async = await adb().connect();
+
+            await setAwsConfig(conn_async);
+            await putTestFileToS3('correct_auth_test', 'csv', test_data_small);
+            const results_with_auth = await conn_async.query(`select * from "s3://${BUCKET_NAME}/correct_auth_test.csv";`);
+            assertTestFileResultCorrect(results_with_auth, test_data_small);
+        });
+
+        it('can read and write parquet file from S3 with correct auth credentials', async () => {
+            conn_async = await adb().connect();
+            await putTestFileToS3('correct_auth_test', 'parquet', test_data_small);
+            await setAwsConfig(conn_async);
+            const results_with_auth = await conn_async.query(`select * from "s3://${BUCKET_NAME}/correct_auth_test.parquet";`);
+            assertTestFileResultCorrect(results_with_auth, test_data_small);
+        });
+
+        it('can not read a file with incorrect credentials', async () => {
+            conn_async = await adb().connect();
+            await putTestFileToS3('incorrect_auth_test', 'parquet', test_data_small);
+            await setAwsConfig(conn_async, AWSConfigType.INVALID);
+
+            await expectAsync(conn_async.query(`select * from "s3://${BUCKET_NAME}/incorrect_auth_test.csv";`))
+                .toBeRejected();
+        });
+
+        it('properly invalidates file caches on settings update.', async () => {
+            conn_async = await adb().connect();
+            await putTestFileToS3('file_cache_invalidation_test', 'parquet', test_data_large);
+            await setAwsConfig(conn_async);
+
+            // Query first row of column
+            const results_correct = await conn_async.query(`select l_partkey from "s3://${BUCKET_NAME}/file_cache_invalidation_test.parquet" limit 1;`);
+            expect(results_correct.getColumnAt(0)?.get(0)).toEqual(1552);
+
+            // Query scanning whole column should fail now
+            await setAwsConfig(conn_async, AWSConfigType.INVALID);
+            await expectAsync(conn_async!.query(`select avg(l_partkey) from "s3://${BUCKET_NAME}/lineitem.parquet";`))
+                .toBeRejected();
+        });
+
+        it('write after read throws incorrect flag error without dropping files', async () => {
+            conn_async = await adb().connect();
+            await setAwsConfig(conn_async);
+
+            // Write the file for the first time
+            await conn_async.query(`COPY (SELECT * FROM range(1000,1010) tbl(i)) TO 's3://${BUCKET_NAME}/test_written.csv' (FORMAT 'csv');`);
+
+            // Confirm file matches
+            const result = await conn_async.query(`SELECT * FROM "s3://${BUCKET_NAME}/test_written.csv";`);
+            expect(result.getColumnAt(0)?.get(6)).toEqual(1006);
+
+            // Write the file for the second time should fail: the read flag will not be set on this file
+            await expectAsync(conn_async!.query(`COPY (SELECT * FROM range(2000,2010) tbl(i)) TO 's3://${BUCKET_NAME}/test_written.csv' (FORMAT 'csv');`))
+                .toBeRejectedWithError("File is not opened in write mode");
+        });
+
+        // validate authorization headers for known requests, based on: https://czak.pl/2015/09/15/s3-rest-api-with-curl.html
+        it('s3 helper passes validation', () => {
+            const testParams1 : S3Params = {
+                url: "/",
+                query: "",
+                host: "my-precious-bucket.s3.amazonaws.com",
+                region: "us-east-1",
+                service: "s3",
+                method: "GET",
+                accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+                secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                sessionToken: "",
+                dateNow: "20150915",
+                datetimeNow: "20150915T124500Z",
+            };
+            const result = createS3Headers(testParams1).get("Authorization");
+            expect(result).toEqual("AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20150915/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=182072eb53d85c36b2d791a1fa46a12d23454ec1e921b02075c23aee40166d5a");
+
+            const canonical_query_string = "delimiter=%2F&encoding-type=url&list-type=2&prefix="; // aws s3 ls <bucket>
+            const testParams2 : S3Params = {
+                url: "/",
+                query: canonical_query_string,
+                host: "my-precious-bucket.s3.eu-west-1.amazonaws.com",
+                region: "eu-west-1",
+                service: "s3",
+                method: "GET",
+                accessKeyId: "ASIAYSPIOYDTHTBIITVC",
+                secretAccessKey: "vs1BZPxSL2qVARBSg5vCMKJsavCoEPlo/HSHRaVe",
+                sessionToken: "IQoJb3JpZ2luX2VjENX//////////wEaCWV1LXdlc3QtMSJHMEUCIQDfjzs9BYHrEXDMU/NR+PHV1uSTr7CSVSQdjKSfiPRLdgIgCCztF0VMbi9+uHHAfBVKhV4t9MlUrQg3VAOIsLxrWyoqlAIIHRAAGgw1ODk0MzQ4OTY2MTQiDOGl2DsYxENcKCbh+irxARe91faI+hwUhT60sMGRFg0GWefKnPclH4uRFzczrDOcJlAAaQRJ7KOsT8BrJlrY1jSgjkO7PkVjPp92vi6lJX77bg99MkUTJActiOKmd84XvAE5bFc/jFbqechtBjXzopAPkKsGuaqAhCenXnFt6cwq+LZikv/NJGVw7TRphLV+Aq9PSL9XwdzIgsW2qXwe1c3rxDNj53yStRZHVggdxJ0OgHx5v040c98gFphzSULHyg0OY6wmCMTYcswpb4kO2IIi6AiD9cY25TlwPKRKPi5CdBsTPnyTeW62u7PvwK0fTSy4ZuJUuGKQnH2cKmCXquEwoOHEiQY6nQH9fzY/EDGHMRxWWhxu0HiqIfsuFqC7GS0p0ToKQE+pzNsvVwMjZc+KILIDDQpdCWRIwu53I5PZy2Cvk+3y4XLvdZKQCsAKqeOc4c94UAS4NmUT7mCDOuRV0cLBVM8F0JYBGrUxyI+YoIvHhQWmnRLuKgTb5PkF7ZWrXBHFWG5/tZDOvBbbaCWTlRCL9b0Vpg5+BM/81xd8jChP4w83",
+                dateNow: "20210904",
+                datetimeNow: "20210904T121746Z",
+            };
+            const result2 = createS3Headers(testParams2).get("Authorization");
+            expect(result2).toEqual("AWS4-HMAC-SHA256 Credential=ASIAYSPIOYDTHTBIITVC/20210904/eu-west-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=4d9d6b59d7836b6485f6ad822de97be40287da30347d83042ea7fbed530dc4c0");
+
+            const testParams3 : S3Params = {
+                url: "/correct_auth_test.csv",
+                query: "",
+                host: "test-bucket-ceiveran.s3.amazonaws.com",
+                region: "eu-west-1",
+                service: "s3",
+                method: "PUT",
+                accessKeyId: "S3RVER",
+                secretAccessKey: "S3RVER",
+                sessionToken: "",
+                dateNow: "20220121",
+                datetimeNow: "20220121T141452Z",
+            };
+            const test3PayloadParams : S3PayloadParams = {
+                contentHash: "28a0cf6ac5c4cb73793091fe6ecc6a68bf90855ac9186158748158f50241bb0c",
+                contentType: "text/data;charset=utf-8"
+            }
+            const result3 = createS3Headers(testParams3, test3PayloadParams).get("Authorization");
+            expect(result3).toEqual("AWS4-HMAC-SHA256 Credential=S3RVER/20220121/eu-west-1/s3/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=5d9a6cbfaa78a6d0f2ab7df0445e2f1cc9c80cd3655ac7de9e7219c036f23f02");
+
+            expect(uriEncode("/category=Books/")).toEqual("/category%3DBooks/");
+            expect(uriEncode("/?category=Books&title=Ducks Retreat/")).toEqual("/%3Fcategory%3DBooks%26title%3DDucks%20Retreat/");
+            expect(uriEncode("/?category=Books&title=Ducks Retreat/", true)).toEqual("%2F%3Fcategory%3DBooks%26title%3DDucks%20Retreat%2F");
+        });
     });
 }

--- a/packages/duckdb-wasm/test/httpfs_test.ts
+++ b/packages/duckdb-wasm/test/httpfs_test.ts
@@ -163,6 +163,27 @@ export function testHTTPFS(adb: () => duckdb.AsyncDuckDB, sdb: () => duckdb.Duck
             expect(globalFileInfoUpdated?.s3Config?.region).toEqual("");
         });
 
+        // NOTE: this test now works
+        // TODO: next up:
+        // - Parquet files
+        // - Can I trigger weird file flags?
+        // - Large file
+        // it('can write to s3 file with correct auth credentials', async () => {
+        //     await adb().reset();
+        //     conn_async = await adb().connect();
+        //
+        //     await conn_async.query("SET s3_region='nope';");
+        //     await conn_async.query("SET s3_access_key_id='nope';");
+        //     await conn_async.query("SET s3_secret_access_key='nope';");
+        //
+        //     await conn_async.query("CREATE TABLE test AS SELECT * FROM \"s3://test-bucket-ceiveran/test.csv\";");
+        //     await conn_async.query("COPY (SELECT * FROM test) TO 's3://test-bucket-ceiveran/test_written.csv' (FORMAT 'csv');");
+        //
+        //     // File should be written now!
+        //     const result = await conn_async.query("SELECT * FROM \"s3://test-bucket-ceiveran/test_written.csv\";");
+        //     expect(result.getColumnAt(2)?.get(2)).toEqual(9);
+        // });
+
         // TODO: find a way to run these tests in CI
         // it('can fetch s3 file with correct auth credentials', async () => {
         //     conn_async = await adb().connect();

--- a/packages/duckdb-wasm/test/index_browser.ts
+++ b/packages/duckdb-wasm/test/index_browser.ts
@@ -67,8 +67,8 @@ const resolveData = async (url: string) => {
             return await resolveBuffer('/uni/hoeren.parquet');
         case '/uni/vorlesungen.parquet':
             return await resolveBuffer('/uni/vorlesungen.parquet');
-        case '/tpch/0_1/parquet/lineitem.parquet':
-            return await resolveBuffer('/tpch/0_1/parquet/lineitem.parquet');
+        case '/tpch/0_01/parquet/lineitem.parquet':
+            return await resolveBuffer('/tpch/0_01/parquet/lineitem.parquet');
         default:
             return null;
     }

--- a/packages/duckdb-wasm/test/index_browser.ts
+++ b/packages/duckdb-wasm/test/index_browser.ts
@@ -67,6 +67,8 @@ const resolveData = async (url: string) => {
             return await resolveBuffer('/uni/hoeren.parquet');
         case '/uni/vorlesungen.parquet':
             return await resolveBuffer('/uni/vorlesungen.parquet');
+        case '/tpch/0_1/parquet/lineitem.parquet':
+            return await resolveBuffer('/tpch/0_1/parquet/lineitem.parquet');
         default:
             return null;
     }
@@ -114,7 +116,7 @@ testTableNames(() => db!);
 testTableNamesAsync(() => adb!);
 testRegressionAsync(() => adb!);
 testAllTypes(() => db!);
-testHTTPFS(() => adb!, () => db!);
+testHTTPFS(() => adb!, () => db!, resolveData, dataURL);
 testAllTypesAsync(() => adb!);
 testBindings(() => db!, dataURL);
 testAsyncBindings(() => adb!, dataURL);

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,6 +208,15 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
@@ -269,6 +278,17 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+
+"@koa/router@^9.0.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@koa/router/-/router-9.4.0.tgz#734b64c0ae566eb5af752df71e4143edc4748e48"
+  integrity sha512-dOOXgzqaDoHu5qqMEPLKEgLz5CeIA7q8+1W62mCvFVCOqeC71UoTGJ4u1xUSOpIl2J1x2pqrNULkFteUeZW3/A==
+  dependencies:
+    debug "^4.1.1"
+    http-errors "^1.7.3"
+    koa-compose "^4.1.0"
+    methods "^1.1.2"
+    path-to-regexp "^6.1.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -853,7 +873,7 @@ abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
-accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
+accepts@^1.3.5, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
@@ -1124,6 +1144,11 @@ async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+async@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1313,6 +1338,13 @@ buffer@^5.2.1, buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+busboy@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.3.1.tgz#170899274c5bf38aae27d5c62b71268cd585fd1b"
+  integrity sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==
+  dependencies:
+    dicer "0.3.0"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -1322,6 +1354,19 @@ bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
+bytes@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
+  integrity sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==
+
+cache-content-type@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-content-type/-/cache-content-type-1.0.1.tgz#035cde2b08ee2129f4a8315ea8f00a00dba1453c"
+  integrity sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==
+  dependencies:
+    mime-types "^2.1.18"
+    ylru "^1.2.0"
 
 caching-transform@^4.0.0:
   version "4.0.0"
@@ -1462,12 +1507,17 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+
 color-convert@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
   integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -1486,10 +1536,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.1.4, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.0.tgz#63b6ebd1bec11999d1df3a79a7569451ac2be8aa"
+  integrity sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colorette@^2.0.10, colorette@^2.0.14:
   version "2.0.14"
@@ -1500,6 +1566,14 @@ colors@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 command-line-args@5.0.2:
   version "5.0.2"
@@ -1546,6 +1620,11 @@ commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 commander@^7.0.0, commander@^7.2.0:
   version "7.2.0"
@@ -1619,7 +1698,14 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
-content-type@~1.0.4:
+content-disposition@~0.5.2:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
+content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -1645,6 +1731,14 @@ cookie@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookies@~0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"
+  integrity sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==
+  dependencies:
+    depd "~2.0.0"
+    keygrip "~1.1.0"
 
 copy-anything@^2.0.1:
   version "2.0.3"
@@ -1841,6 +1935,11 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
+deep-equal@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
+
 deep-extend@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -1891,6 +1990,16 @@ del@^6.0.0:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+depd@^2.0.0, depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -1901,7 +2010,7 @@ dequal@^2.0.2:
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
   integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
-destroy@~1.0.4:
+destroy@^1.0.4, destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
@@ -1920,6 +2029,13 @@ di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
+
+dicer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.0.tgz#eacd98b3bfbf92e8ab5c2fdb71aaac44bb06b872"
+  integrity sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==
+  dependencies:
+    streamsearch "0.1.2"
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2060,7 +2176,12 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-encodeurl@~1.0.2:
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
+
+encodeurl@^1.0.2, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
@@ -2299,7 +2420,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -2564,6 +2685,13 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-xml-parser@^3.12.19:
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz#152a1d51d445380f7046b304672dd55d15c9e736"
+  integrity sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==
+  dependencies:
+    strnum "^1.0.4"
+
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
@@ -2594,6 +2722,11 @@ fd-slicer@~1.1.0:
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
+
+fecha@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
+  integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2690,6 +2823,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
+
 follow-redirects@^1.0.0:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
@@ -2740,7 +2878,7 @@ framesync@6.0.1:
   dependencies:
     tslib "^2.1.0"
 
-fresh@0.5.2:
+fresh@0.5.2, fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
@@ -2755,7 +2893,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^8.1.0:
+fs-extra@^8.0.0, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -3051,6 +3189,14 @@ htmlparser2@^6.1.0:
     domutils "^2.5.2"
     entities "^2.0.0"
 
+http-assert@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.5.0.tgz#c389ccd87ac16ed2dfa6246fd73b926aa00e6b8f"
+  integrity sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==
+  dependencies:
+    deep-equal "~1.0.1"
+    http-errors "~1.8.0"
+
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -3066,6 +3212,17 @@ http-errors@1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
 
 http-errors@~1.6.2:
   version "1.6.3"
@@ -3144,6 +3301,11 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+humanize-number@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/humanize-number/-/humanize-number-0.0.2.tgz#11c0af6a471643633588588048f1799541489c18"
+  integrity sha1-EcCvakcWQ2M1iFiASPF5lUFInBg=
 
 iconv-lite@0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
@@ -3297,6 +3459,11 @@ is-arguments@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -3787,6 +3954,13 @@ karma@^6.3.11:
     ua-parser-js "^0.7.30"
     yargs "^16.1.1"
 
+keygrip@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
+  integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
+  dependencies:
+    tsscmp "1.0.6"
+
 kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
@@ -3796,6 +3970,63 @@ kleur@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.4.tgz#8c202987d7e577766d039a8cd461934c01cda04d"
   integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
+
+koa-compose@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
+  integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
+
+koa-convert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/koa-convert/-/koa-convert-2.0.0.tgz#86a0c44d81d40551bae22fee6709904573eea4f5"
+  integrity sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==
+  dependencies:
+    co "^4.6.0"
+    koa-compose "^4.1.0"
+
+koa-logger@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/koa-logger/-/koa-logger-3.2.1.tgz#ab9db879526db3837cc9ce4fd983c025b1689f22"
+  integrity sha512-MjlznhLLKy9+kG8nAXKJLM0/ClsQp/Or2vI3a5rbSQmgl8IJBQO0KI5FA70BvW+hqjtxjp49SpH2E7okS6NmHg==
+  dependencies:
+    bytes "^3.1.0"
+    chalk "^2.4.2"
+    humanize-number "0.0.2"
+    passthrough-counter "^1.0.0"
+
+koa@^2.7.0:
+  version "2.13.4"
+  resolved "https://registry.yarnpkg.com/koa/-/koa-2.13.4.tgz#ee5b0cb39e0b8069c38d115139c774833d32462e"
+  integrity sha512-43zkIKubNbnrULWlHdN5h1g3SEKXOEzoAlRsHOTFpnlDu8JlAOZSMJBLULusuXRequboiwJcj5vtYXKB3k7+2g==
+  dependencies:
+    accepts "^1.3.5"
+    cache-content-type "^1.0.0"
+    content-disposition "~0.5.2"
+    content-type "^1.0.4"
+    cookies "~0.8.0"
+    debug "^4.3.2"
+    delegates "^1.0.0"
+    depd "^2.0.0"
+    destroy "^1.0.4"
+    encodeurl "^1.0.2"
+    escape-html "^1.0.3"
+    fresh "~0.5.2"
+    http-assert "^1.3.0"
+    http-errors "^1.6.3"
+    is-generator-function "^1.0.7"
+    koa-compose "^4.1.0"
+    koa-convert "^2.0.0"
+    on-finished "^2.3.0"
+    only "~0.0.2"
+    parseurl "^1.3.2"
+    statuses "^1.5.0"
+    type-is "^1.6.16"
+    vary "^1.1.2"
+
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
 
 less@^4.1.1:
   version "4.1.2"
@@ -3878,7 +4109,7 @@ lodash.padend@^4.6.1:
   resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
   integrity sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3893,6 +4124,17 @@ log4js@^6.3.0:
     flatted "^2.0.1"
     rfdc "^1.1.4"
     streamroller "^2.2.4"
+
+logform@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.3.2.tgz#68babe6a74ab09a1fd15a9b1e6cbc7713d41cb5b"
+  integrity sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==
+  dependencies:
+    colors "1.4.0"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^1.1.0"
+    triple-beam "^1.3.0"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -3972,7 +4214,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -3989,6 +4231,18 @@ mime-db@1.50.0, "mime-db@>= 1.43.0 < 2":
   version "1.50.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
   integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
+
+mime-db@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
+  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+
+mime-types@^2.1.18:
+  version "2.1.34"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
+  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  dependencies:
+    mime-db "1.51.0"
 
 mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24:
   version "2.1.33"
@@ -4304,7 +4558,7 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
@@ -4323,12 +4577,24 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
+
 onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+only@~0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
+  integrity sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
 
 open@^8.0.9:
   version "8.2.1"
@@ -4441,7 +4707,7 @@ parse-node-version@^1.0.1:
   resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
   integrity sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
 
-parseurl@~1.3.2, parseurl@~1.3.3:
+parseurl@^1.3.2, parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -4453,6 +4719,11 @@ pascal-case@^3.1.2:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
+
+passthrough-counter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/passthrough-counter/-/passthrough-counter-1.0.0.tgz#1967d9e66da572b5c023c787db112a387ab166fa"
+  integrity sha1-GWfZ5m2lcrXAI8eH2xEqOHqxZvo=
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -4478,6 +4749,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -5074,15 +5350,37 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+s3rver@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/s3rver/-/s3rver-3.7.1.tgz#aa4ef573969f944d4fdfb0ddf28ccd7e980f9673"
+  integrity sha512-H9KIX6n8NqcfoE4ziFNbQASBQfjcNJgb+3wbT9L5iotEqfOncFO1c38cfJSFSo7xXTu1zM9HA6t2u9xKNlYRaA==
+  dependencies:
+    "@koa/router" "^9.0.0"
+    busboy "^0.3.1"
+    commander "^5.0.0"
+    fast-xml-parser "^3.12.19"
+    fs-extra "^8.0.0"
+    he "^1.2.0"
+    koa "^2.7.0"
+    koa-logger "^3.2.0"
+    lodash "^4.17.5"
+    statuses "^2.0.0"
+    winston "^3.0.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-stable-stringify@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz#c8a220ab525cd94e60ebf47ddc404d610dc5d84a"
+  integrity sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.1.2:
   version "2.1.2"
@@ -5226,6 +5524,11 @@ setprototypeof@1.1.1:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
 shallow-clone@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
@@ -5267,6 +5570,13 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
   integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sirv@^1.0.7:
   version "1.0.17"
@@ -5425,10 +5735,20 @@ sql.js@^1.6.2:
   resolved "https://registry.yarnpkg.com/sql.js/-/sql.js-1.6.2.tgz#7fb70ff68089434826a39b8f5afb2170d682eb3f"
   integrity sha512-9iucI5fXQa+Gspeqf/BNB20PxJIn5LhXDt4mjXoFPqXdR+NqtFs15SdKpSIJ6s529aGL9zFR9p2eSCIEiMsNGA==
 
-"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
+"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0, statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+statuses@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
 std-env@^3.0.1:
   version "3.0.1"
@@ -5443,6 +5763,11 @@ streamroller@^2.2.4:
     date-format "^2.1.0"
     debug "^4.1.1"
     fs-extra "^8.1.0"
+
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
@@ -5530,6 +5855,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strnum@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 style-loader@^3.3.1:
   version "3.3.1"
@@ -5681,6 +6011,11 @@ text-encoding-utf-8@^1.0.2:
   resolved "https://registry.yarnpkg.com/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz#585b62197b0ae437e3c7b5d0af27ac1021e10d13"
   integrity sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -5720,6 +6055,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
 totalist@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
@@ -5729,6 +6069,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 ts-loader@^9.1.0, ts-loader@^9.2.2:
   version "9.2.6"
@@ -5760,6 +6105,11 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tsscmp@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -5784,7 +6134,7 @@ type-fest@^0.8.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-is@~1.6.17, type-is@~1.6.18:
+type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
@@ -5953,7 +6303,7 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-vary@^1, vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
@@ -6232,6 +6582,30 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
+winston-transport@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.2.tgz#554efe3fce229d046df006e0e3c411d240652e51"
+  integrity sha512-9jmhltAr5ygt5usgUTQbEiw/7RYXpyUbEAFRCSicIacpUzPkrnQsQZSPGEI12aLK9Jth4zNcYJx3Cvznwrl8pw==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.4.0"
+    triple-beam "^1.2.0"
+
+winston@^3.0.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.4.0.tgz#7080f24b02a0684f8a37f9d5c6afb1ac23e95b84"
+  integrity sha512-FqilVj+5HKwCfIHQzMxrrd5tBIH10JTS3koFGbLVWBODjiIYq7zir08rFyBT4rrTYG/eaTqDcfSIbcjSM78YSw==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.3.2"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.2"
+
 word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -6386,6 +6760,11 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+ylru@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.2.1.tgz#f576b63341547989c1de7ba288760923b27fe84f"
+  integrity sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Implemented basic implementation for writing  HTTP/S3 files. The files are converted to buffers on opening to allow writes. On closing the file we upload the buffer synchronously with a single HTTP PUT request. For large uploads we should look into multipart uploads. I can look into that after implementing s3 writes in DuckDB as well.

I also added a local test s3 server using [S3rver](https://www.npmjs.com/package/s3rver). It seems to work quite well, but as discussed with @ankoh, we should keep an eye on its stability and possibly change it for something more solid such as [minio]{https://min.io/}. switching to minio should be quite simple but complicate the local dev

Note that s3rver only really seems to validate the credentials and does not actually check the authorization signature, therefore I added a testcase to the manual validation of the auth header to make this a bit more solid.