### PR TITLE
UDF extensions part one

### DIFF
--- a/lib/js-stubs.js
+++ b/lib/js-stubs.js
@@ -47,7 +47,7 @@ mergeInto(LibraryManager.library, {
     duckdb_web_fs_file_remove: function (path, pathLen) {
         return globalThis.DUCKDB_RUNTIME.removeFile(Module, path, pathLen);
     },
-    duckdb_web_udf_scalar_call: function (funcId, bufferPtr, bufferSize, response) {
-        return globalThis.DUCKDB_RUNTIME.callScalarUDF(Module, funcId, bufferPtr, bufferSize, response);
+    duckdb_web_udf_scalar_call: function (funcId, descPtr, descSize, ptrsPtr, ptrsSize, response) {
+        return globalThis.DUCKDB_RUNTIME.callScalarUDF(Module, funcId, descPtr, descSize, ptrsPtr, ptrsSize, response);
     },
 });

--- a/packages/duckdb-wasm/src/bindings/runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime.ts
@@ -145,7 +145,7 @@ export interface DuckDBRuntime {
     removeFile(mod: DuckDBModule, pathPtr: number, pathLen: number): void;
 
     // Call a scalar UDF function
-    callScalarUDF(mod: DuckDBModule, response: number, funcId: number, bufferPtr: number, bufferSize: number): void;
+    callScalarUDF(mod: DuckDBModule, response: number, funcId: number, descPtr: number, descSize: number, ptrsPtr: number, ptrsSize: number): void;
 }
 
 export const DEFAULT_RUNTIME: DuckDBRuntime = {
@@ -184,9 +184,11 @@ export const DEFAULT_RUNTIME: DuckDBRuntime = {
         mod: DuckDBModule,
         response: number,
         funcId: number,
-        bufferPtr: number,
-        bufferSize: number,
+        descPtr: number,
+        descSize: number,
+        ptrsPtr: number,
+        ptrsSize: number,
     ): void => {
-        udf_rt.callScalarUDF(DEFAULT_RUNTIME, mod, response, funcId, bufferPtr, bufferSize);
+        udf_rt.callScalarUDF(DEFAULT_RUNTIME, mod, response, funcId, descPtr, descSize, ptrsPtr, ptrsSize);
     },
 };

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -424,10 +424,12 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         mod: DuckDBModule,
         response: number,
         funcId: number,
-        bufferPtr: number,
-        bufferSize: number,
+        descPtr: number,
+        descSize: number,
+        ptrsPtr: number,
+        ptrsSize: number,
     ): void => {
-        udf.callScalarUDF(BROWSER_RUNTIME, mod, response, funcId, bufferPtr, bufferSize);
+        udf.callScalarUDF(BROWSER_RUNTIME, mod, response, funcId, descPtr, descSize, ptrsPtr, ptrsSize);
     },
 };
 

--- a/packages/duckdb-wasm/src/bindings/runtime_node.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_node.ts
@@ -272,10 +272,12 @@ export const NODE_RUNTIME: DuckDBRuntime & {
         mod: DuckDBModule,
         response: number,
         funcId: number,
-        bufferPtr: number,
-        bufferSize: number,
+        descPtr: number,
+        descSize: number,
+        ptrsPtr: number,
+        ptrsSize: number,
     ): void => {
-        udf.callScalarUDF(NODE_RUNTIME, mod, response, funcId, bufferPtr, bufferSize);
+        udf.callScalarUDF(NODE_RUNTIME, mod, response, funcId, descPtr, descSize, ptrsPtr, ptrsSize);
     },
 };
 

--- a/packages/duckdb-wasm/src/bindings/udf_runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/udf_runtime.ts
@@ -97,7 +97,7 @@ export function callScalarUDF(
         // create argument arrays
         for (const idx in desc.args) {
             const arg = desc.args[idx];
-            var arg_arr = ptr_to_arr(mod, Number(ptrs[arg.data_buffer]), arg.physical_type, desc.rows);
+            const arg_arr = ptr_to_arr(mod, Number(ptrs[arg.data_buffer]), arg.physical_type, desc.rows);
             const validity = ptr_to_arr(mod, Number(ptrs[arg.validity_buffer]), 'UINT8', desc.rows);
 
             if (arg_arr.length == 0 || validity.length == 0) {

--- a/packages/duckdb-wasm/src/bindings/udf_runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/udf_runtime.ts
@@ -14,31 +14,118 @@ function storeError(mod: DuckDBModule, response: number, message: string) {
     mod.HEAPF64[(response >> 3) + 2] = heapArray.byteLength;
 }
 
+function type_size(ptype: string) {
+    switch(ptype) {
+        case 'INT8':
+            return 1;
+        case 'INT32':
+            return 4;
+        case 'FLOAT':
+            return 4;
+        case 'DOUBLE':
+            return 8;
+        default:
+            return 0;
+    }
+}
+
+function ptr_to_arr(mod: DuckDBModule, ptr: number, ptype: string, n:number) {
+    const in_buf = mod.HEAPU8.subarray(ptr, ptr + n * type_size(ptype));
+
+    switch(ptype) {
+        case 'INT8': {
+            return new Int8Array(in_buf.buffer, in_buf.byteOffset, n);
+        }
+        case 'INT32': {
+            return new Int32Array(in_buf.buffer, in_buf.byteOffset, n);
+        }
+        case 'FLOAT': {
+            return new Float32Array(in_buf.buffer, in_buf.byteOffset, n);
+        }
+        case 'DOUBLE': {
+            return new Float64Array(in_buf.buffer, in_buf.byteOffset, n);
+        }
+        default:
+            return undefined;
+    }
+}
+
 export function callScalarUDF(
     runtime: DuckDBRuntime,
     mod: DuckDBModule,
     response: number,
     funcId: number,
-    bufferPtr: number,
-    bufferSize: number,
+    descPtr: number,
+    descSize: number,
+    ptrsPtr: number,
+    ptrsSize: number,
 ) {
     try {
         const udf = runtime._udfFunctions.get(funcId);
         if (!udf) {
-            storeError(mod, response, 'unknown udf with id: ' + funcId);
+            storeError(mod, response, 'Unknown UDF with id: ' + funcId);
             return;
         }
 
-        const data = mod.HEAPU8.subarray(bufferPtr, bufferPtr + bufferSize);
-        const in0 = new Int32Array(data.buffer, data.byteOffset, bufferSize / 4);
+        // schema description as json
+        const desc_str = new TextDecoder().decode(mod.HEAPU8.subarray(descPtr, descPtr + descSize));
+        const desc = JSON.parse(desc_str);
 
-        const outLen = in0.length * 4;
+        // array of buffer pointers referred to from schema
+        const ptrs_buf = mod.HEAPU8.subarray(ptrsPtr, ptrsPtr + ptrsSize);
+        const ptrs = new BigUint64Array(ptrs_buf.buffer, ptrs_buf.byteOffset, ptrsSize / 8);
+        const in_arr = [];
+        const validity_arr = [];
+
+        // create argument arrays
+        for (const idx in desc.args) {
+            const arg = desc.args[idx];
+            const arg_arr = ptr_to_arr(mod, Number(ptrs[arg.data_buffer]), arg.physical_type, desc.rows);
+            // TODO check if there are any NULLs
+            const validity = ptr_to_arr(mod, Number(ptrs[arg.validity_buffer]), 'INT8', desc.rows);
+
+            if (!arg_arr || !validity) {
+                storeError(mod, response, "Can't create physical arrays for argument");
+                return;
+            }
+            in_arr.push(arg_arr);
+            validity_arr.push(validity);
+
+        }
+
+        // console.log(desc);
+
+        // create output array
+        const outLen = desc.rows * type_size(desc.ret.physical_type);
         const outAddr = mod._malloc(outLen);
-        const outArray = mod.HEAPU8.subarray(outAddr, outAddr + outLen);
-        const out = new Int32Array(outArray.buffer, outArray.byteOffset, outLen);
+        const out = ptr_to_arr(mod, outAddr, desc.ret.physical_type, desc.rows);
 
-        for (let i = 0; i < in0.length; ++i) {
-            out[i] = udf.func(in0[i]);
+        // actually call the function
+        if (!out) {
+            storeError(mod, response, "Can't create physical arrays for result");
+            return;
+        } else {
+            // TODO can we do something with .apply() here?
+            switch (desc.args.length) {
+                case 0:
+                    for (let i = 0; i < desc.rows; ++i) {
+                        out[i] = udf.func();
+                    }
+                    break;
+                case 1:
+                    for (let i = 0; i < desc.rows; ++i) {
+                        out[i] = udf.func(validity_arr[0][i] ? in_arr[0][i] : undefined);
+                    }
+                    break;
+                case 2:
+                    for (let i = 0; i < desc.rows; ++i) {
+                        out[i] = udf.func(validity_arr[0][i] ? in_arr[0][i] : undefined, validity_arr[1][i] ? in_arr[1][i] : undefined);
+                    }
+                    break;
+                default:
+                    storeError(mod, response, "Can't deal with argument count: " + desc.args.length);
+                    return;
+            }
         }
 
         mod.HEAPF64[(response >> 3) + 0] = 0;

--- a/packages/duckdb-wasm/src/bindings/udf_runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/udf_runtime.ts
@@ -16,13 +16,16 @@ function storeError(mod: DuckDBModule, response: number, message: string) {
 
 function type_size(ptype: string) {
     switch(ptype) {
+        case 'UINT8':
         case 'INT8':
             return 1;
         case 'INT32':
-            return 4;
         case 'FLOAT':
             return 4;
+        case 'INT64':
+        case 'UINT64':
         case 'DOUBLE':
+        case 'VARCHAR':
             return 8;
         default:
             return 0;
@@ -33,11 +36,20 @@ function ptr_to_arr(mod: DuckDBModule, ptr: number, ptype: string, n:number) {
     const in_buf = mod.HEAPU8.subarray(ptr, ptr + n * type_size(ptype));
 
     switch(ptype) {
+        case 'UINT8': {
+            return new Uint8Array(in_buf.buffer, in_buf.byteOffset, n);
+        }
         case 'INT8': {
             return new Int8Array(in_buf.buffer, in_buf.byteOffset, n);
         }
         case 'INT32': {
             return new Int32Array(in_buf.buffer, in_buf.byteOffset, n);
+        }
+        case 'INT64': {
+            return new BigInt64Array(in_buf.buffer, in_buf.byteOffset, n);
+        }
+        case 'UINT64': {
+            return new BigUint64Array(in_buf.buffer, in_buf.byteOffset, n);
         }
         case 'FLOAT': {
             return new Float32Array(in_buf.buffer, in_buf.byteOffset, n);
@@ -45,11 +57,15 @@ function ptr_to_arr(mod: DuckDBModule, ptr: number, ptype: string, n:number) {
         case 'DOUBLE': {
             return new Float64Array(in_buf.buffer, in_buf.byteOffset, n);
         }
+        case 'VARCHAR': {
+            return new BigUint64Array(in_buf.buffer, in_buf.byteOffset, n);
+        }
         default:
-            return undefined;
+            return new Uint8Array();
     }
 }
 
+// this is called from webdb.cc/CallScalarUDFFunction, changes here need to be matched there
 export function callScalarUDF(
     runtime: DuckDBRuntime,
     mod: DuckDBModule,
@@ -70,67 +86,101 @@ export function callScalarUDF(
         // schema description as json
         const desc_str = new TextDecoder().decode(mod.HEAPU8.subarray(descPtr, descPtr + descSize));
         const desc = JSON.parse(desc_str);
+        //console.log(desc);
 
         // array of buffer pointers referred to from schema
         const ptrs_buf = mod.HEAPU8.subarray(ptrsPtr, ptrsPtr + ptrsSize);
         const ptrs = new BigUint64Array(ptrs_buf.buffer, ptrs_buf.byteOffset, ptrsSize / 8);
-        const in_arr = [];
         const validity_arr = [];
+        const data_arr = [];
 
         // create argument arrays
         for (const idx in desc.args) {
             const arg = desc.args[idx];
-            const arg_arr = ptr_to_arr(mod, Number(ptrs[arg.data_buffer]), arg.physical_type, desc.rows);
-            // TODO check if there are any NULLs
-            const validity = ptr_to_arr(mod, Number(ptrs[arg.validity_buffer]), 'INT8', desc.rows);
+            var arg_arr = ptr_to_arr(mod, Number(ptrs[arg.data_buffer]), arg.physical_type, desc.rows);
+            const validity = ptr_to_arr(mod, Number(ptrs[arg.validity_buffer]), 'UINT8', desc.rows);
 
-            if (!arg_arr || !validity) {
-                storeError(mod, response, "Can't create physical arrays for argument");
+            if (arg_arr.length == 0 || validity.length == 0) {
+                storeError(mod, response, "Can't create physical arrays for argument " + arg.physical_type);
                 return;
             }
-            in_arr.push(arg_arr);
             validity_arr.push(validity);
 
-        }
+            // some special handling for more involved types
+            if (arg.physical_type == 'VARCHAR') {
+                const length_arr = ptr_to_arr(mod, Number(ptrs[arg.length_buffer]), 'UINT64', desc.rows);
 
-        // console.log(desc);
+                const string_data_arr = [];
+                const decoder = new TextDecoder();
+                for (let i = 0; i < desc.rows; ++i) {
+                    if (!validity[i]) {
+                        string_data_arr.push(undefined);
+                        continue;
+                    }
+                    const subarray = mod.HEAPU8.subarray(Number(arg_arr[i]), Number(arg_arr[i]) + Number(length_arr[i]));
+                    const str = decoder.decode(subarray);
+                    string_data_arr.push(str);
+                }
+                data_arr.push(string_data_arr);
 
-        // create output array
-        const outLen = desc.rows * type_size(desc.ret.physical_type);
-        const outAddr = mod._malloc(outLen);
-        const out = ptr_to_arr(mod, outAddr, desc.ret.physical_type, desc.rows);
-
-        // actually call the function
-        if (!out) {
-            storeError(mod, response, "Can't create physical arrays for result");
-            return;
-        } else {
-            // TODO can we do something with .apply() here?
-            switch (desc.args.length) {
-                case 0:
-                    for (let i = 0; i < desc.rows; ++i) {
-                        out[i] = udf.func();
-                    }
-                    break;
-                case 1:
-                    for (let i = 0; i < desc.rows; ++i) {
-                        out[i] = udf.func(validity_arr[0][i] ? in_arr[0][i] : undefined);
-                    }
-                    break;
-                case 2:
-                    for (let i = 0; i < desc.rows; ++i) {
-                        out[i] = udf.func(validity_arr[0][i] ? in_arr[0][i] : undefined, validity_arr[1][i] ? in_arr[1][i] : undefined);
-                    }
-                    break;
-                default:
-                    storeError(mod, response, "Can't deal with argument count: " + desc.args.length);
-                    return;
+            } else {
+                data_arr.push(arg_arr);
             }
         }
 
-        mod.HEAPF64[(response >> 3) + 0] = 0;
-        mod.HEAPF64[(response >> 3) + 1] = outAddr;
-        mod.HEAPF64[(response >> 3) + 2] = outLen;
+        // create output array
+        // TODO we probably do not want to recreate those every time
+         const out_data_len = desc.rows * type_size(desc.ret.physical_type);
+        const out_data_ptr = mod._malloc(out_data_len);
+        const out_data = ptr_to_arr(mod, out_data_ptr, desc.ret.physical_type, desc.rows);
+
+        const out_validity_ptr = mod._malloc(desc.rows);
+        const out_validity = ptr_to_arr(mod, out_validity_ptr, 'UINT8', desc.rows);
+
+        // actually call the function
+        if (out_data.length == 0 || out_validity.length == 0) {
+            storeError(mod, response, "Can't create physical arrays for result");
+            return;
+        }
+        // TODO can we do something with .apply() here?
+        switch (desc.args.length) {
+            case 0:
+                for (let i = 0; i < desc.rows; ++i) {
+                    const res = udf.func();
+                    out_data[i] = res;
+                    out_validity[i] = res == undefined ? 0 : 1;
+                }
+                break;
+            case 1:
+                for (let i = 0; i < desc.rows; ++i) {
+                    const res = udf.func(validity_arr[0][i] ? data_arr[0][i] : undefined);
+                    out_data[i] = res;
+                    out_validity[i] = res == undefined ? 0 : 1;
+                }
+                break;
+            case 2:
+                for (let i = 0; i < desc.rows; ++i) {
+                    const res = udf.func(validity_arr[0][i] ? data_arr[0][i] : undefined, validity_arr[1][i] ? data_arr[1][i] : undefined);
+                    out_data[i] = res;
+                    out_validity[i] = res == undefined ? 0 : 1;
+                }
+                break;
+            default:
+                storeError(mod, response, "Can't deal with argument count: " + desc.args.length);
+                return;
+        }
+
+        const out_len = 6*8; // need to store three pointers, data, validity and length
+        // TODO maybe we can re-use this buffer, too
+        const out_ptr = mod._malloc(out_len);
+        const out_arr = ptr_to_arr(mod, out_ptr, 'UINT64', 6);
+        // TODO this is a bit strange still, does not align quite right on the other side but works (TM)
+        out_arr[0] = BigInt(out_data_ptr);
+        out_arr[1] = BigInt(out_validity_ptr);
+
+        mod.HEAPF64[(response >> 3) + 0] = 0; // status
+        mod.HEAPF64[(response >> 3) + 1] = out_ptr;
+        mod.HEAPF64[(response >> 3) + 2] = out_len;
     } catch (e: any) {
         storeError(mod, response, e.toString());
     }

--- a/packages/duckdb-wasm/test/udf.test.ts
+++ b/packages/duckdb-wasm/test/udf.test.ts
@@ -1,5 +1,5 @@
 import * as duckdb from '../src/';
-import { Int32 } from 'apache-arrow';
+import {Float64, Int32} from 'apache-arrow';
 
 export function testUDF(db: () => duckdb.DuckDBBindings): void {
     let conn: duckdb.DuckDBConnection;
@@ -16,6 +16,7 @@ export function testUDF(db: () => duckdb.DuckDBBindings): void {
     describe('UDF', () => {
         it('simple', async () => {
             conn.createScalarFunction('jsudf', new Int32(), a => a);
+
             const result = conn.query(
                 'SELECT max(jsudf(v::INTEGER))::INTEGER as foo FROM generate_series(1, 10000) as t(v)',
             );
@@ -24,6 +25,55 @@ export function testUDF(db: () => duckdb.DuckDBBindings): void {
             expect(result.numCols).toEqual(1);
             expect(result.getColumnAt(0)?.length).toEqual(1);
             expect(result.getColumnAt(0)?.toArray()).toEqual(new Int32Array([10000]));
+        });
+
+        it('double', async () => {
+            conn.createScalarFunction('jsudf2', new Float64(), a => a);
+
+            const result = conn.query(
+                'SELECT max(jsudf2(v::DOUBLE))::DOUBLE as foo FROM generate_series(1, 10000) as t(v)',
+            );
+
+            expect(result.length).toEqual(1);
+            expect(result.numCols).toEqual(1);
+            expect(result.getColumnAt(0)?.length).toEqual(1);
+            expect(result.getColumnAt(0)?.toArray()).toEqual(new Float64Array([10000]));
+        });
+
+        it('twoargs', async () => {
+            conn.createScalarFunction('jsudf3', new Int32(), (a, b) => a + b);
+
+            const result = conn.query(
+                'SELECT max(jsudf3(v::INTEGER, v::INTEGER))::INTEGER as foo FROM generate_series(1, 10000) as t(v)',
+            );
+
+            expect(result.length).toEqual(1);
+            expect(result.numCols).toEqual(1);
+            expect(result.getColumnAt(0)?.length).toEqual(1);
+            expect(result.getColumnAt(0)?.toArray()).toEqual(new Int32Array([20000]));
+        });
+
+        it('noargs', async () => {
+            conn.createScalarFunction('jsudf4', new Int32(), () => 42);
+            const result = conn.query(
+                'SELECT max(jsudf4())::INTEGER as foo FROM generate_series(1, 10000) as t(v)',
+            );
+
+            expect(result.length).toEqual(1);
+            expect(result.numCols).toEqual(1);
+            expect(result.getColumnAt(0)?.length).toEqual(1);
+            expect(result.getColumnAt(0)?.toArray()).toEqual(new Int32Array([42]));
+        });
+        it('withnulls', async () => {
+            conn.createScalarFunction('jsudf5', new Int32(), a => a == undefined ? -100 : a);
+            const result = conn.query(
+                'SELECT min(jsudf5((case when v % 2 = 0 then v else null end)::INTEGER))::INTEGER as foo FROM generate_series(1, 10000) as t(v)',
+            );
+
+            expect(result.length).toEqual(1);
+            expect(result.numCols).toEqual(1);
+            expect(result.getColumnAt(0)?.length).toEqual(1);
+            expect(result.getColumnAt(0)?.toArray()).toEqual(new Int32Array([-100]));
         });
     });
 }


### PR DESCRIPTION
- UDFs can now have 0, 1, 2, or 3 arguments
- Arguments can be `NULL`, return values can be `NULL`
- `VARCHAR` and `DOUBLE` arguments and return values, also `TINYINT`/`SMALLINT`/`INTEGER` and their unsigned versions