### PR TITLE
refactor: use tableToIPC directly

### DIFF
--- a/packages/duckdb-wasm/src/bindings/connection.ts
+++ b/packages/duckdb-wasm/src/bindings/connection.ts
@@ -78,9 +78,7 @@ export class DuckDBConnection {
 
     /** Insert an arrow table */
     public insertArrowTable(table: arrow.Table, options: ArrowInsertOptions): void {
-        const writer = new arrow.RecordBatchStreamWriter();
-        writer.writeAll(table);
-        const buffer = writer.toUint8Array(true);
+        const buffer = arrow.tableToIPC(table);
         this.insertArrowFromIPCStream(buffer, options);
     }
     /** Insert an arrow table from an ipc stream */

--- a/packages/duckdb-wasm/src/bindings/connection.ts
+++ b/packages/duckdb-wasm/src/bindings/connection.ts
@@ -78,7 +78,7 @@ export class DuckDBConnection {
 
     /** Insert an arrow table */
     public insertArrowTable(table: arrow.Table, options: ArrowInsertOptions): void {
-        const buffer = arrow.tableToIPC(table);
+	const buffer = arrow.tableToIPC(table, 'stream');
         this.insertArrowFromIPCStream(buffer, options);
     }
     /** Insert an arrow table from an ipc stream */


### PR DESCRIPTION
So we are consistent with the async bindings. 