### PR TITLE
Use MANUAL_BUNDLES where applicable

### DIFF
--- a/packages/duckdb-wasm/README.md
+++ b/packages/duckdb-wasm/README.md
@@ -52,7 +52,7 @@ const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     },
 };
 // Select a bundle based on browser checks
-const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
 // Instantiate the asynchronus version of DuckDB-wasm
 const worker = new Worker(bundle.mainWorker!);
 const logger = new duckdb.ConsoleLogger();
@@ -78,7 +78,7 @@ const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     },
 };
 // Select a bundle based on browser checks
-const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
 // Instantiate the asynchronus version of DuckDB-wasm
 const worker = new Worker(bundle.mainWorker!);
 const logger = new duckdb.ConsoleLogger();
@@ -100,7 +100,7 @@ const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     },
 };
 // Select a bundle based on browser checks
-const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
 // Instantiate the asynchronus version of DuckDB-wasm
 const worker = new Worker(bundle.mainWorker!);
 const logger = new duckdb.ConsoleLogger();


### PR DESCRIPTION
Replace JSDELIVERY_BUNDLES by MANUAL_BUNDLES where applicable
I was not able to test the changes but reading the code it seems like in the last 3 examples it should be referring to MANUAL_BUNDLES