### PR TITLE
Update DuckDB to v0.6.0

### DIFF
--- a/lib/cmake/duckdb.cmake
+++ b/lib/cmake/duckdb.cmake
@@ -35,6 +35,7 @@ ExternalProject_Add(
     <INSTALL_DIR>/lib/libduckdb_re2.a
     <INSTALL_DIR>/lib/libduckdb_static.a
     <INSTALL_DIR>/lib/libduckdb_fmt.a
+    <INSTALL_DIR>/lib/libduckdb_fsst.a
     <INSTALL_DIR>/lib/libduckdb_hyperloglog.a
     <INSTALL_DIR>/lib/libduckdb_miniz.a
     <INSTALL_DIR>/lib/libduckdb_mbedtls.a
@@ -64,6 +65,7 @@ target_link_libraries(
   duckdb
   INTERFACE ${install_dir}/lib/libduckdb_re2.a
   INTERFACE ${install_dir}/lib/libduckdb_fmt.a
+  INTERFACE ${install_dir}/lib/libduckdb_fsst.a
   INTERFACE ${install_dir}/lib/libduckdb_hyperloglog.a
   INTERFACE ${install_dir}/lib/libduckdb_miniz.a
   INTERFACE ${install_dir}/lib/libduckdb_mbedtls.a

--- a/lib/cmake/duckdb.cmake
+++ b/lib/cmake/duckdb.cmake
@@ -30,6 +30,7 @@ ExternalProject_Add(
              -DBUILD_JSON_EXTENSION=TRUE
              -DBUILD_SHELL=FALSE
              -DBUILD_UNITTESTS=FALSE
+             -DBUILD_JEMALLOC_EXTENSION=FALSE
              -DDISABLE_BUILTIN_EXTENSIONS=TRUE
   BUILD_BYPRODUCTS
     <INSTALL_DIR>/lib/libduckdb_re2.a

--- a/lib/test/all_types_test.cc
+++ b/lib/test/all_types_test.cc
@@ -283,8 +283,7 @@ TEST(AllTypesTest, FullRangeTypes) {
     AssertParamTypeCorrect<arrow::Time64Type, uint64_t>("time_tz", 0, 86399999999, batch,
                                                         arrow::time64(arrow::TimeUnit::MICRO));
     AssertSimpleTypeCorrect<arrow::Date32Type, int32_t>("date", -2147483646, 2147483646, batch);
-
-    AssertSimpleTypeCorrect<arrow::StringType>("varchar", "🦆🦆🦆🦆🦆🦆", "goose", batch);
+    AssertSimpleTypeCorrect<arrow::StringType>("varchar", "🦆🦆🦆🦆🦆🦆"s, "goo\x00se"s, batch);
     AssertSimpleTypeCorrect<arrow::BinaryType>("blob", "thisisalongblob\x00withnullbytes"s, "\x00\x00\x00\x61"s, batch);
 
     // Decimal types

--- a/lib/test/web_filesystem_test.cc
+++ b/lib/test/web_filesystem_test.cc
@@ -33,7 +33,7 @@ bool CHECK_COLUMN(MaterializedQueryResult& result, uint32_t column, vector<Value
     }
     for (uint32_t row_idx = 0; row_idx < values.size(); row_idx++) {
         auto actual_val = result.GetValue(column, row_idx);
-        if (!Value::ValuesAreEqual(values[row_idx], actual_val)) {
+        if (!Value::DefaultValuesAreEqual(values[row_idx], actual_val)) {
             auto expected_str = values[row_idx].ToString();
             auto actual_str = actual_val.ToString();
             printf(

--- a/packages/duckdb-wasm/test/all_types.test.ts
+++ b/packages/duckdb-wasm/test/all_types.test.ts
@@ -88,7 +88,7 @@ const FULLY_IMPLEMENTED_ANSWER_MAP: AnswerObjectType = {
 
     float: [-3.4028234663852886e38, 3.4028234663852886e38, null],
     double: [-1.7976931348623157e308, 1.7976931348623157e308, null],
-    varchar: ['🦆🦆🦆🦆🦆🦆', 'goose', null],
+    varchar: ['🦆🦆🦆🦆🦆🦆', 'goo\x00se', null],
     small_enum: ['DUCK_DUCK_ENUM', 'GOOSE', null],
     medium_enum: ['enum_0', 'enum_299', null],
     large_enum: ['enum_0', 'enum_69999', null],


### PR DESCRIPTION
Fixes:

* `Value::ValuesAreEqual` requires a ClientContext now, move to `Value::DefaultValuesAreEqual`
* Link to FSST
* Disable jemalloc
* `test_all_types` now contains a null byte in "goose" (`goo\x00se`)