### PR TITLE
Add node module as esbuild externals for browser bundles

### DIFF
--- a/packages/duckdb-wasm/bundle.mjs
+++ b/packages/duckdb-wasm/bundle.mjs
@@ -41,6 +41,7 @@ const TARGET_NODE = ['node14.6'];
 const EXTERNALS_NODE = ['apache-arrow'];
 const EXTERNALS_BROWSER = ['apache-arrow', 'module'];
 const EXTERNALS_WEBWORKER = ['module'];
+const EXTERNALS_TEST_BROWSER = ['module'];
 
 // Read CLI flags
 let is_debug = false;
@@ -291,7 +292,7 @@ fs.copyFile(path.resolve(src, 'bindings', 'duckdb-coi.wasm'), path.resolve(dist,
         target: TARGET_BROWSER_TEST,
         bundle: true,
         sourcemap: is_debug ? 'inline' : true,
-        external: EXTERNALS_BROWSER,
+        external: EXTERNALS_TEST_BROWSER,
     });
 
     console.log('[ ESBUILD ] tests-node.cjs');

--- a/packages/duckdb-wasm/bundle.mjs
+++ b/packages/duckdb-wasm/bundle.mjs
@@ -39,8 +39,8 @@ const TARGET_BROWSER = ['chrome64', 'edge79', 'firefox62', 'safari11.1'];
 const TARGET_BROWSER_TEST = ['es2020'];
 const TARGET_NODE = ['node14.6'];
 const EXTERNALS_NODE = ['apache-arrow'];
-const EXTERNALS_BROWSER = ['apache-arrow'];
-const EXTERNALS_WEBWORKER = [];
+const EXTERNALS_BROWSER = ['apache-arrow', 'module'];
+const EXTERNALS_WEBWORKER = ['module'];
 
 // Read CLI flags
 let is_debug = false;
@@ -291,6 +291,7 @@ fs.copyFile(path.resolve(src, 'bindings', 'duckdb-coi.wasm'), path.resolve(dist,
         target: TARGET_BROWSER_TEST,
         bundle: true,
         sourcemap: is_debug ? 'inline' : true,
+        external: EXTERNALS_BROWSER,
     });
 
     console.log('[ ESBUILD ] tests-node.cjs');


### PR DESCRIPTION
Starting with emscripten 3.1.27, the generated javascript will conditionally include several node-specific modules:
```
 if (ENVIRONMENT_IS_NODE) {
    const {createRequire: createRequire} = await import("module");
    var fs = require("fs");
    ...
  }
```

Processing this code causes esbuild to fail with:
```
The package "module" wasn't found on the file system but is built into node. Are you trying to bundle for node? You can use "platform: 'node'" to do that, which will remove this error.
```

Per [esbuild suggestion](https://github.com/evanw/esbuild/issues/2852), this PR marks `module` as an external package for all browser-based builds.