### PR TITLE
Allow core DuckDB to be external folder

### DIFF
--- a/lib/cmake/duckdb.cmake
+++ b/lib/cmake/duckdb.cmake
@@ -7,12 +7,17 @@ if(EMSCRIPTEN)
   set(DUCKDB_BUILD_TYPE Release)
 endif()
 
+set(DUCKDB_CORE_DIR "${CMAKE_SOURCE_DIR}/../submodules/duckdb")
+if(DUCKDB_LOCATION)
+  set(DUCKDB_CORE_DIR ${DUCKDB_LOCATION})
+endif()
+
 set(DUCKDB_CXX_FLAGS "${DUCKDB_CXX_FLAGS} -Wno-unqualified-std-cast-call")
 message("DUCKDB_CXX_FLAGS=${DUCKDB_CXX_FLAGS}")
 
 ExternalProject_Add(
   duckdb_ep
-  SOURCE_DIR "${CMAKE_SOURCE_DIR}/../submodules/duckdb"
+  SOURCE_DIR "${DUCKDB_CORE_DIR}"
   PREFIX "${CMAKE_BINARY_DIR}/third_party/duckdb"
   INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/duckdb/install"
   CMAKE_ARGS -G${CMAKE_GENERATOR}
@@ -51,7 +56,7 @@ ExternalProject_Add(
 ExternalProject_Get_Property(duckdb_ep install_dir)
 ExternalProject_Get_Property(duckdb_ep binary_dir)
 
-set(DUCKDB_SOURCE_DIR "${CMAKE_SOURCE_DIR}/../submodules/duckdb")
+set(DUCKDB_SOURCE_DIR "${DUCKDB_CORE_DIR}")
 set(DUCKDB_INCLUDE_DIR "${install_dir}/include")
 set(DUCKDB_UTF8PROC_INCLUDE_DIR
     "${DUCKDB_SOURCE_DIR}/third_party/utf8proc/include")

--- a/scripts/wasm_build_lib.sh
+++ b/scripts/wasm_build_lib.sh
@@ -8,7 +8,9 @@ PROJECT_ROOT="$(cd $(dirname "$BASH_SOURCE[0]") && cd .. && pwd)" &> /dev/null
 
 MODE=${1:-Fast}
 FEATURES=${2:-mvp}
+DUCKDB_LOCATION=${3:-"$PROJECT_ROOT/submodules/duckdb"}
 echo "MODE=${MODE}"
+echo "${DUCKDB_LOCATION}"
 
 CPP_BUILD_DIR="${PROJECT_ROOT}/lib/build/wasm/${MODE}"
 CPP_SOURCE_DIR="${PROJECT_ROOT}/lib"
@@ -54,6 +56,7 @@ emcmake cmake \
     -B${BUILD_DIR} \
     -DCMAKE_C_COMPILER_LAUNCHER=ccache \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DDUCKDB_LOCATION=${DUCKDB_LOCATION} \
     ${ADDITIONAL_FLAGS}
 
 emmake make \


### PR DESCRIPTION
This is needed useful for testing the WebAssembly builds for core repo, there the workflow will be like:

```
git clone duckdb/duckdb-wasm
cd duckdb-wasm
git checkout latest_stable
./script/wasm_build_lib.sh relsize mvp $(pwd)/..
./script/wasm_build_lib.sh relsize eh $(pwd)/..
./script/wasm_build_lib.sh relsize coi $(pwd)/..
```

This will test duckdb branches against a somehow stable and tested version of duckdb-wasm (to avoid problems like breakages in duckdb-wasm affecting duckdb development) and some degree of reproducibilty.

Once this lands in duckdb-wasm/master, I would say creating a branch called stable / latest_stable (that includes this changes) will allow to file the dependent PR on duckdb/duckdb that would look like this: https://github.com/carlopi/duckdb/commit/75549d41063a8991ba68d0421dd41c06364cbdb2

(note that this already uncovered a bug, I believe, here: https://github.com/carlopi/duckdb/actions/runs/4383302686/jobs/7673377396)