### PR TITLE
Avoid double-includes

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -178,8 +178,7 @@ endif()
 # ---------------------------------------------------------------------------
 # Headers
 
-include_directories("${CMAKE_SOURCE_DIR}/include" "${CMAKE_BINARY_DIR}/include"
-                    "${DUCKDB_INCLUDE_DIR}" "${DUCKDB_UTF8PROC_INCLUDE_DIR}")
+include_directories("${CMAKE_SOURCE_DIR}/include" "${DUCKDB_UTF8PROC_INCLUDE_DIR}")
 
 # ---------------------------------------------------------------------------
 # Libraries


### PR DESCRIPTION
We are currently facing a flaky build error with symbols being redefined (cf. below).
Our understanding is that these two include directory are not needed for the build and may cause more harm.

Let us know if we missed anything.

Thanks!

cc @ywelsch

```c++
In file included from ../../../../../../../../submodules/duckdb/src/include/duckdb.hpp:13:
../../../../../../../../submodules/duckdb/src/include/duckdb/main/query_result.hpp:19:12: error: redefinition of 'QueryResultType'
enum class QueryResultType : uint8_t { MATERIALIZED_RESULT, STREAM_RESULT, PENDING_RESULT };
           ^
../../../../third_party/duckdb/install/include/duckdb/main/query_result.hpp:19:12: note: previous definition is here
enum class QueryResultType : uint8_t { MATERIALIZED_RESULT, STREAM_RESULT, PENDING_RESULT };
           ^
In file included from ../../../../../../../../submodules/duckdb/src/include/duckdb.hpp:13:
../../../../../../../../submodules/duckdb/src/include/duckdb/main/query_result.hpp:22:8: error: redefinition of 'ClientProperties'
struct ClientProperties {
       ^
../../../../third_party/duckdb/install/include/duckdb/main/query_result.hpp:22:8: note: previous definition is here
struct ClientProperties {
       ^
In file included from ../../../../../../../../submodules/duckdb/src/include/duckdb.hpp:13:
../../../../../../../../submodules/duckdb/src/include/duckdb/main/query_result.hpp:26:7: error: redefinition of 'BaseQueryResult'
class BaseQueryResult {
      ^
../../../../third_party/duckdb/install/include/duckdb/main/query_result.hpp:26:7: note: previous definition is here
class BaseQueryResult {
      ^
In file included from ../../../../../../../../submodules/duckdb/src/include/duckdb.hpp:13:
../../../../../../../../submodules/duckdb/src/include/duckdb/main/query_result.hpp:65:7: error: redefinition of 'QueryResult'
class QueryResult : public BaseQueryResult {
      ^
../../../../third_party/duckdb/install/include/duckdb/main/query_result.hpp:65:7: note: previous definition is here
class QueryResult : public BaseQueryResult {
```