### PR TITLE
Push (even empty commit) on gh-pages should trigger deployment

### DIFF
--- a/scripts/deploy_pages.sh
+++ b/scripts/deploy_pages.sh
@@ -58,3 +58,6 @@ git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 git add -A .
 git commit --amend --reset-author -m "Deploy GitHub Pages"
 git push origin HEAD:gh-pages --force
+
+git commit -m 'Force rebuild/deployment of pages' --allow-empty
+git push origin gh-pages


### PR DESCRIPTION
Main script will execute a force-push, that apparently do not seems to trigger deployment

This seems to make some sense, and should have no bad consequences, but I am far from sure of the results, but the only reliable test is merging and waiting to see if this does end up triggering a deployment.