### PR TITLE
Fix duckdb version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,40 +378,22 @@ jobs:
                   submodules: 'recursive'
                   fetch-depth: 0
 
+            - uses: mymindstorm/setup-emsdk@v12
+              with:
+                  version: 3.1.24
+
+            - name: Setup Ccache
+              uses: hendrikmuhs/ccache-action@main
+              with:
+                key: ${{ github.job }}
+
             - name: Git submodule status
               run: |
                   git submodule status > git_submodule_status.txt
 
-            - name: Cache WASM build
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      ./.emscripten_cache
-                      ./.ccache
-                  key: ${{ runner.os }}-wasm6-default-${{ hashFiles('git_submodule_status.txt') }}-${{ hashFiles('lib/src/**') }}-${{ hashFiles('lib/include/**') }}
-                  restore-keys: |
-                      ${{ runner.os }}-wasm6-default-${{ hashFiles('git_submodule_status.txt') }}
-                      ${{ runner.os }}-wasm6-default-
-
-            - name: Prepare repository
-              run: |
-                  chown -R $(id -u):$(id -g) $PWD
-                  (cd ./submodules/duckdb && git fetch --all --tags)
-
-            - name: Prepare environment
-              uses: duckdb/duckdb-wasm-ci-env@v0.11
-              with:
-                  script: |-
-                      ccache --max-size 300M
-                      ccache -s
-
             - name: Build WASM module
-              uses: duckdb/duckdb-wasm-ci-env@v0.11
-              with:
-                  script: |-
-                      ccache -z
-                      ./scripts/wasm_build_lib.sh relperf mvp
-                      ccache -s
+              run: |
+                  ./scripts/wasm_build_lib.sh relperf mvp
 
             - name: Upload artifact
               uses: actions/upload-artifact@v3
@@ -434,40 +416,22 @@ jobs:
                   submodules: 'recursive'
                   fetch-depth: 0
 
+            - uses: mymindstorm/setup-emsdk@v12
+              with:
+                  version: 3.1.24
+
+            - name: Setup Ccache
+              uses: hendrikmuhs/ccache-action@main
+              with:
+                key: ${{ github.job }}
+
             - name: Git submodule status
               run: |
                   git submodule status > git_submodule_status.txt
 
-            - name: Cache WASM build
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      ./.emscripten_cache
-                      ./.ccache
-                  key: ${{ runner.os }}-wasm6-eh-${{ hashFiles('git_submodule_status.txt') }}-${{ hashFiles('lib/src/**') }}-${{ hashFiles('lib/include/**') }}
-                  restore-keys: |
-                      ${{ runner.os }}-wasm6-eh-${{ hashFiles('git_submodule_status.txt') }}
-                      ${{ runner.os }}-wasm6-eh-
-
-            - name: Prepare repository
-              run: |
-                  chown -R $(id -u):$(id -g) $PWD
-                  (cd ./submodules/duckdb && git fetch --all --tags)
-
-            - name: Prepare environment
-              uses: duckdb/duckdb-wasm-ci-env@v0.11
-              with:
-                  script: |-
-                      ccache --max-size 300M
-                      ccache -s
-
             - name: Build WASM module
-              uses: duckdb/duckdb-wasm-ci-env@v0.11
-              with:
-                  script: |-
-                      ccache -z
-                      ./scripts/wasm_build_lib.sh relperf eh
-                      ccache -s
+              run: |
+                  ./scripts/wasm_build_lib.sh relperf eh
 
             - name: Upload artifact
               uses: actions/upload-artifact@v3
@@ -490,40 +454,22 @@ jobs:
                   submodules: 'recursive'
                   fetch-depth: 0
 
+            - uses: mymindstorm/setup-emsdk@v12
+              with:
+                  version: 3.1.24
+
+            - name: Setup Ccache
+              uses: hendrikmuhs/ccache-action@main
+              with:
+                key: ${{ github.job }}
+
             - name: Git submodule status
               run: |
                   git submodule status > git_submodule_status.txt
 
-            - name: Cache WASM build
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      ./.emscripten_cache
-                      ./.ccache
-                  key: ${{ runner.os }}-wasm6-coi-${{ hashFiles('git_submodule_status.txt') }}-${{ hashFiles('lib/src/**') }}-${{ hashFiles('lib/include/**') }}
-                  restore-keys: |
-                      ${{ runner.os }}-wasm6-coi-${{ hashFiles('git_submodule_status.txt') }}
-                      ${{ runner.os }}-wasm6-coi-
-
-            - name: Prepare repository
-              run: |
-                  chown -R $(id -u):$(id -g) $PWD
-                  (cd ./submodules/duckdb && git fetch --all --tags)
-
-            - name: Prepare environment
-              uses: duckdb/duckdb-wasm-ci-env@v0.11
-              with:
-                  script: |-
-                      ccache --max-size 300M
-                      ccache -s
-
             - name: Build WASM module
-              uses: duckdb/duckdb-wasm-ci-env@v0.11
-              with:
-                  script: |-
-                      ccache -z
-                      ./scripts/wasm_build_lib.sh relperf coi
-                      ccache -s
+              run: |
+                  ./scripts/wasm_build_lib.sh relperf coi
 
             - name: Upload artifact
               uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: 'Main'
 on:
     push:
     pull_request:
-        branches:
-            - master
     create:
         tags:
             - v*

--- a/packages/duckdb-wasm/test/bindings.test.ts
+++ b/packages/duckdb-wasm/test/bindings.test.ts
@@ -28,6 +28,17 @@ export function testBindings(db: () => duckdb.DuckDBBindings, baseURL: string): 
             });
         });
 
+        describe('Check version', () => {
+            it('Version check', async () => {
+                await db().reset();
+                conn = db().connect();
+                const version = conn.query<{ name: arrow.Utf8 }>("select * from (select version()) where version() != 'v0.0.1-dev0';");
+                const rows = version.toArray();
+                expect(rows.length).toEqual(1);
+                await db().reset();
+            });
+        });
+
         //describe('Open', () => {
         // XXX apparently synchronous XHR on the main thread does not allow for arraybuffer response type?
         // it('Remote TPCH 0_01', async () => {


### PR DESCRIPTION
In the CI we build the WebAssembly components outside of docker, and that makes for the version to be correctly detected.

This fixes a longstanding issue in #1234, and add a tests that `select version()` should return something that makes sense.

Emscripten version pinned for now at 3.1.24.