### PR TITLE
Emscripten: Add more exported runtime methods

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -318,7 +318,7 @@ if(EMSCRIPTEN)
           _duckdb_web_tokenize, \
           _duckdb_web_udf_scalar_create \
       ]' \
-      -s EXPORTED_RUNTIME_METHODS='[\"ccall\"]' \
+      -s EXPORTED_RUNTIME_METHODS='[\"ccall\", \"stackSave\", \"stackAlloc\", \"stackRestore\"]' \
       --js-library=${CMAKE_SOURCE_DIR}/js-stubs.js")
 
 endif()


### PR DESCRIPTION
This is compatible both with 3.1.24, currently used by CI, and latest available emscripten release (3.1.34).