### PR TITLE
Fix #1251: readFile should be robust to empty ranges

### DIFF
--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -389,6 +389,10 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         return 0;
     },
     readFile(mod: DuckDBModule, fileId: number, buf: number, bytes: number, location: number) {
+        if (bytes == 0) {
+            // Be robust to empty reads
+            return 0;
+        }
         try {
             const file = BROWSER_RUNTIME.getFileInfo(mod, fileId);
             switch (file?.dataProtocol) {


### PR DESCRIPTION
In case where bytes is 0, read will potentially issue a ranged request on (location, location-1), and this will end up in a failure.
Returning 0 means that 0 bytes have been read, so it's sort of consistent.

I haven't got a local repro (yet), then there is to investigate also why readFile on an empty range is issued.