### PR TITLE
feat: Allow configuring access mode

### DIFF
--- a/lib/include/duckdb/web/config.h
+++ b/lib/include/duckdb/web/config.h
@@ -75,6 +75,8 @@ struct FileSystemConfig {
 struct WebDBConfig {
     /// The database path
     std::string path = "";
+    /// The access mode
+    std::optional<int8_t> access_mode = std::nullopt;
     /// The thread count
     uint32_t maximum_threads = 1;
     /// The query config

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -37,6 +37,7 @@ uint32_t ResolveFeatureFlags() {
 /// Read the webdb config
 WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
     auto config = WebDBConfig{.path = ":memory:",
+                              .access_mode = std::nullopt,
                               .maximum_threads = 1,
                               .query =
                                   QueryConfig{
@@ -61,6 +62,9 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
     if (ok) {
         if (doc.HasMember("path") && doc["path"].IsString()) {
             config.path = doc["path"].GetString();
+        }
+        if (doc.HasMember("accessMode") && doc["accessMode"].IsNumber()) {
+            config.access_mode = doc["accessMode"].GetInt();
         }
         if (doc.HasMember("maximumThreads") && doc["maximumThreads"].IsNumber()) {
             config.maximum_threads = doc["maximumThreads"].GetInt();

--- a/packages/duckdb-wasm/src/bindings/config.ts
+++ b/packages/duckdb-wasm/src/bindings/config.ts
@@ -28,7 +28,7 @@ export interface DuckDBFilesystemConfig {
     allowFullHTTPReads?: boolean;
 }
 
-export enum AccessMode {
+export enum DuckDBAccessMode {
     UNDEFINED = 0,
     AUTOMATIC = 1,
     READ_ONLY = 2,
@@ -43,7 +43,7 @@ export interface DuckDBConfig {
     /**
      * The read only mode
      */
-    accessMode?: AccessMode;
+    accessMode?: DuckDBAccessMode;
     /**
      * The maximum number of threads.
      * Note that this will only work with cross-origin isolated sites since it requires SharedArrayBuffers.

--- a/packages/duckdb-wasm/src/bindings/config.ts
+++ b/packages/duckdb-wasm/src/bindings/config.ts
@@ -28,11 +28,22 @@ export interface DuckDBFilesystemConfig {
     allowFullHTTPReads?: boolean;
 }
 
+export enum AccessMode {
+    UNDEFINED = 0,
+    AUTOMATIC = 1,
+    READ_ONLY = 2,
+    READ_WRITE = 3,
+}
+
 export interface DuckDBConfig {
     /**
      * The database path
      */
     path?: string;
+    /**
+     * The read only mode
+     */
+    accessMode?: AccessMode;
     /**
      * The maximum number of threads.
      * Note that this will only work with cross-origin isolated sites since it requires SharedArrayBuffers.

--- a/packages/duckdb-wasm/src/bindings/config.ts
+++ b/packages/duckdb-wasm/src/bindings/config.ts
@@ -41,7 +41,7 @@ export interface DuckDBConfig {
      */
     path?: string;
     /**
-     * The read only mode
+     * The access mode
      */
     accessMode?: DuckDBAccessMode;
     /**


### PR DESCRIPTION
Riffing on https://github.com/duckdb/duckdb-wasm/pull/1075, completes the wiring of the config to the database and removes the unnecessary enum handler (enums are passed through as numbers).