### PR TITLE
Adapt to newer ToArrowSchema signature

### DIFF
--- a/lib/src/webdb.cc
+++ b/lib/src/webdb.cc
@@ -102,13 +102,12 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> WebDB::Connection::MaterializeQuer
     current_query_result_.reset();
     current_schema_.reset();
     current_schema_patched_.reset();
-    std::string timezone_config;
 
     // Configure the output writer
     ArrowSchema raw_schema;
     ArrowOptions options;
     options.offset_size = ArrowOffsetSize::REGULAR;
-    ArrowConverter::ToArrowSchema(&raw_schema, result->types, result->names, timezone_config, options);
+    ArrowConverter::ToArrowSchema(&raw_schema, result->types, result->names, options);
     ARROW_ASSIGN_OR_RAISE(auto schema, arrow::ImportSchema(&raw_schema));
 
     // Patch the schema (if necessary)
@@ -138,14 +137,13 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> WebDB::Connection::StreamQueryResu
     current_query_result_ = std::move(result);
     current_schema_.reset();
     current_schema_patched_.reset();
-    std::string timezone_config;
 
     // Import the schema
     ArrowSchema raw_schema;
     ArrowOptions options;
     options.offset_size = ArrowOffsetSize::REGULAR;
     ArrowConverter::ToArrowSchema(&raw_schema, current_query_result_->types, current_query_result_->names,
-                                  timezone_config, options);
+                                  options);
     ARROW_ASSIGN_OR_RAISE(current_schema_, arrow::ImportSchema(&raw_schema));
     current_schema_patched_ = patchSchema(current_schema_, webdb_.config_->query);
 

--- a/lib/test/arrow_casts_test.cc
+++ b/lib/test/arrow_casts_test.cc
@@ -24,10 +24,9 @@ TEST(ArrowCasts, PatchBigInt) {
 
     // Configure the output writer
     ArrowSchema raw_schema;
-    std::string config_timezone;
     duckdb::ArrowOptions options;
     options.offset_size = duckdb::ArrowOffsetSize::REGULAR;
-    duckdb::ArrowConverter::ToArrowSchema(&raw_schema, result->types, result->names, config_timezone, options);
+    duckdb::ArrowConverter::ToArrowSchema(&raw_schema, result->types, result->names, options);
     auto maybe_schema = arrow::ImportSchema(&raw_schema);
     ASSERT_TRUE(maybe_schema.status().ok());
     auto schema = maybe_schema.MoveValueUnsafe();
@@ -71,10 +70,9 @@ TEST(ArrowCasts, PatchTimestamp) {
 
     // Configure the output writer
     ArrowSchema raw_schema;
-    std::string config_timezone;
     duckdb::ArrowOptions options;
     options.offset_size = duckdb::ArrowOffsetSize::REGULAR;
-    duckdb::ArrowConverter::ToArrowSchema(&raw_schema, result->types, result->names, config_timezone, options);
+    duckdb::ArrowConverter::ToArrowSchema(&raw_schema, result->types, result->names, options);
     auto maybe_schema = arrow::ImportSchema(&raw_schema);
     ASSERT_TRUE(maybe_schema.status().ok());
     auto schema = maybe_schema.MoveValueUnsafe();


### PR DESCRIPTION
This will need to be merged before https://github.com/duckdb/duckdb/pull/7784 (+ updating the duckdb-wasm reference inside duckdb) and then a separate PR should bump duckdb in duckdb-wasm, or some bridge solution to be used in duckdb before this can be merged.

This is expected to eventually fail CI, it's a chicken and egg problem