### PR TITLE
Update react-virtualized 9.22.3 to 9.22.4

### DIFF
--- a/packages/duckdb-wasm-app/package.json
+++ b/packages/duckdb-wasm-app/package.json
@@ -33,7 +33,7 @@
         "react-dom": "^18.2.0",
         "react-popper-tooltip": "^4.4.2",
         "react-router-dom": "^6.14.2",
-        "react-virtualized": "^9.22.3",
+        "react-virtualized": "9.22.4",
         "xterm": "^5.1.0",
         "xterm-addon-fit": "^0.7.0",
         "xterm-addon-web-links": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6194,10 +6194,10 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtualized@^9.22.3:
-  version "9.22.3"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
-  integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
+react-virtualized@9.22.4:
+  version "9.22.4"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.4.tgz#ca1997d9677d520e742b2aec1463712c3e322e52"
+  integrity sha512-HYOQEK1OWWYKt8C3KnjbEOST224kv5D8USPSdo/huAamDttWzQLTtoi/IvWfqwFOr9cCnwUYzqOTStwPrdkqqQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
     clsx "^1.0.4"


### PR DESCRIPTION
Package duckdb-wasm-app has a [dependency on React v18](https://github.com/duckdb/duckdb-wasm/blob/master/packages/duckdb-wasm-app/package.json#L29C11-L29C11). React v18 was added as a peer dependency to react-virtualized in [v9.22.4](https://github.com/bvaughn/react-virtualized/releases/tag/v9.22.4).

The dependency is left pinned to 9.22.4 instead of allowing minor version upgrades. There is a new version of react-virtualized v9.22.5 published to [npm](https://www.npmjs.com/package/react-virtualized/v/9.22.5). There is [no tagged commit](https://github.com/bvaughn/react-virtualized/tags) in the repository for this, and the [changelog](https://github.com/bvaughn/react-virtualized/blob/master/CHANGELOG.md) does not mention v9.22.5. It is understood 9.22.5 is the "NEXT" pre-release version that can wait to pull in.

The goal of this change is to make onboarding easier for new developers. This resolves warnings when running an initial `yarn install` or errors running an initial `npm install` after cloning the repository.

```
warning "workspace-aggregator-952ad36a-0e9d-470f-955e-170f7a1f6542 > @duckdb/duckdb-wasm-app > react-virtualized@9.22.3" has incorrect peer dependency "react@^15.3.0 || ^16.0.0-alpha".
warning "workspace-aggregator-952ad36a-0e9d-470f-955e-170f7a1f6542 > @duckdb/duckdb-wasm-app > react-virtualized@9.22.3" has incorrect peer dependency "react-dom@^15.3.0 || ^16.0.0-alpha".
```