### PR TITLE
expose token types

### DIFF
--- a/packages/duckdb-wasm/src/bindings/index.ts
+++ b/packages/duckdb-wasm/src/bindings/index.ts
@@ -7,3 +7,4 @@ export * from './file_stats';
 export * from './runtime';
 export * from './insert_options';
 export * from './progress';
+export * from './tokens';

--- a/packages/duckdb-wasm/src/targets/duckdb.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb.ts
@@ -1,4 +1,5 @@
 export * from '../bindings/config';
+export * from '../bindings/tokens';
 export * from '../log';
 export * from '../status';
 export * from '../parallel';


### PR DESCRIPTION
Expose the types `ScriptTokens` and `TokenTypes`, defined in `bindings/tokens.ts`, to consumers of `duckdb-wasm`.

This is useful for using the `tokenize` method of `AsyncDuckDB`, which returns a `ScriptTokens` object. Having access to the `TokenTypes` enum is important for interpreting the properties of this object correctly.

For example, consider the following code, added to `examples/esbuild-browser/index.ts`:
```
  const tokens: duckdb.ScriptTokens = await db.tokenize('select 1');
  for (const type of tokens.types) {
      if (type === duckdb.TokenType.KEYWORD) {
          // ...
      }
  }
```
Without this change, both `duckdb.ScriptTokens` and `duckdb.TokenType.KEYWORD` generate errors; with this change, they don't.
