### PR TITLE
Add hint on how to get query result as JSON

### DIFF
--- a/packages/duckdb-wasm/README.md
+++ b/packages/duckdb-wasm/README.md
@@ -210,6 +210,11 @@ for await (const batch of await conn.send<{ v: arrow.Int }>(`
 `)) {
     // ...
 }
+// Get query results as JSON
+const result = await conn.query<{ v: arrow.Int }>(`
+    SELECT * FROM generate_series(1, 100) t(v)
+`);
+const jsonResult = result.toArray().map((row) => row.toJSON());
 // Close the connection to release memory
 await conn.close();
 ```

--- a/packages/duckdb-wasm/README.md
+++ b/packages/duckdb-wasm/README.md
@@ -211,10 +211,10 @@ for await (const batch of await conn.send<{ v: arrow.Int }>(`
     // ...
 }
 // Get query results as JSON
-const result = await conn.query<{ v: arrow.Int }>(`
+const arrowResult = await conn.query<{ v: arrow.Int }>(`
     SELECT * FROM generate_series(1, 100) t(v)
 `);
-const jsonResult = result.toArray().map((row) => row.toJSON());
+const result = arrowResult.toArray().map((row) => row.toJSON());
 // Close the connection to release memory
 await conn.close();
 ```


### PR DESCRIPTION
This will eventually make it easier for people to understand hot to transform the Arrow Table to JSON. As the [Apache Arrow JS Docs](https://arrow.apache.org/docs/js/index.html) as empty, this is not really easy to find.

It's also aligned to the main DuckDB docs at https://duckdb.org/docs/api/wasm/query#arrow-table-to-json