### PR TITLE
esbuild-browser example using coi

### DIFF
--- a/examples/esbuild-browser/.gitignore
+++ b/examples/esbuild-browser/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /*.wasm
 /*.js
+/*.js.map

--- a/examples/esbuild-browser/bundle.mjs
+++ b/examples/esbuild-browser/bundle.mjs
@@ -12,8 +12,35 @@ function printErr(err) {
 
 fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-mvp.wasm'), './duckdb-mvp.wasm', printErr);
 fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-eh.wasm'), './duckdb-eh.wasm', printErr);
+fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-coi.wasm'), './duckdb-coi.wasm', printErr);
 fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-browser-mvp.worker.js'), './duckdb-browser-mvp.worker.js', printErr);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-mvp.worker.js.map'),
+    './duckdb-browser-mvp.worker.js.map',
+    printErr,
+);
 fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-browser-eh.worker.js'), './duckdb-browser-eh.worker.js', printErr);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-eh.worker.js.map'),
+    './duckdb-browser-eh.worker.js.map',
+    printErr,
+);
+fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-browser-coi.worker.js'), './duckdb-browser-coi.worker.js', printErr);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-coi.worker.js.map'),
+    './duckdb-browser-coi.worker.js.map',
+    printErr,
+);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-coi.pthread.worker.js'),
+    './duckdb-browser-coi.pthread.worker.js',
+    printErr,
+);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-coi.pthread.worker.js.map'),
+    './duckdb-browser-coi.pthread.worker.js.map',
+    printErr,
+);
 
 esbuild.build({
     entryPoints: ['./index.ts'],

--- a/examples/esbuild-browser/index.ts
+++ b/examples/esbuild-browser/index.ts
@@ -12,6 +12,11 @@ import * as arrow from 'apache-arrow';
                 mainModule: './duckdb-eh.wasm',
                 mainWorker: './duckdb-browser-eh.worker.js',
             },
+            coi: {
+                mainModule: './duckdb-coi.wasm',
+                mainWorker: './duckdb-browser-coi.worker.js',
+                pthreadWorker: './duckdb-browser-coi.pthread.worker.js',
+            },
         });
 
         const logger = new duckdb.ConsoleLogger();

--- a/examples/esbuild-browser/package.json
+++ b/examples/esbuild-browser/package.json
@@ -10,10 +10,12 @@
     "devDependencies": {
         "esbuild": "^0.19.5",
         "http-server": "^14.1.1",
+        "serve": "^14.2.1",
         "typescript": "^5.2.2"
     },
     "scripts": {
         "build": "node ./bundle.mjs && tsc --noEmit",
-        "server": "http-server"
+        "server": "http-server",
+        "server-coi": "serve"
     }
 }

--- a/examples/esbuild-browser/serve.json
+++ b/examples/esbuild-browser/serve.json
@@ -1,0 +1,11 @@
+{
+  "headers": [
+    {
+      "source": "*",
+      "headers": [
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add the COI build to the esbuild-browser example.

In order for this to work, we need to serve the page with the COI headers (COEP & COOP). Since it doesn't appear that `http-server` supports custom headers, I added an alternate HTTP server, `serve`, along with configuration to set these headers. I've left `http-server` in place, so the non-COI case can still be tested easily.

I've tested this in Chrome, Firefox, and Safari on an M2 Mac (latest versions of all browsers & OS), and it works fine with the basic query in the example. I have not tested other queries. In Chrome and Firefox, I do see multiple (4) network requests for the pthread worker script, which is evidence that multiple threads are being started. I don't see this in Safari; I don't know whether that means multiple threads are not being used, or just that Safari reports this information differently.