### PR TITLE
expose web file type

### DIFF
--- a/packages/duckdb-wasm/src/bindings/index.ts
+++ b/packages/duckdb-wasm/src/bindings/index.ts
@@ -8,3 +8,4 @@ export * from './runtime';
 export * from './insert_options';
 export * from './progress';
 export * from './tokens';
+export * from './web_file';

--- a/packages/duckdb-wasm/src/targets/duckdb.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb.ts
@@ -7,4 +7,4 @@ export * from '../platform';
 export * from '../version';
 export * from '../worker';
 
-export { InstantiationProgress, InstantiationProgressHandler, DuckDBDataProtocol } from '../bindings';
+export { InstantiationProgress, InstantiationProgressHandler, DuckDBDataProtocol, WebFile } from '../bindings';


### PR DESCRIPTION
Export the `WebFile` type from the client library.

This type is returned from the exported method `globFiles` (on `AsyncDuckDB`), but the type itself is not exported, so using that method is challenging in some contexts.