### PR TITLE
fix #1472: update duckdb/wasm-ci's base ubuntu image to 23.10

### DIFF
--- a/actions/image/Dockerfile
+++ b/actions/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:23.10
 
 RUN apt-get update -qq \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
This PR solves #1472. Tested and the make command succeeded. The issue occurs because ubuntu 22.10 (kinetic) reached end of life on July 20th.