### PR TITLE
Link embind

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -163,7 +163,7 @@ else()
 endif()
 
 if (DUCKDB_WASM_LOADABLE_EXTENSIONS)
-  set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -s MAIN_MODULE=1 -s  -s EXPORT_ALL=1 -s FILESYSTEM=1 -s ENVIRONMENT='web,worker' -s ALLOW_TABLE_GROWTH")
+  set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -s MAIN_MODULE=1 -s  -s EXPORT_ALL=1 -s FILESYSTEM=1 -s ENVIRONMENT='web,worker' -s ALLOW_TABLE_GROWTH -lembind")
 else()
   set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -s FILESYSTEM=0 -s ENVIRONMENT='web,node,worker'")
 endif()
@@ -261,7 +261,7 @@ add_library(
 add_library(
   duckdb_web_excel
   ${CMAKE_SOURCE_DIR}/src/extensions/excel_extension.cc)
-  
+
 add_library(
   duckdb_web_json
   ${CMAKE_SOURCE_DIR}/src/extensions/json_extension.cc)


### PR DESCRIPTION
Emscripten necessitate that you link all libraries with the main module in order for the dynamically-loaded modules to use them.

So in order to use [Embind](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html) tooling in a DuckDB loadable extension, we need to link `embind` with the main module.

This is what this PR enable.