### PR TITLE
Expose `DUCKDB_BINDINGS` in global scope

### DIFF
--- a/packages/duckdb-wasm/src/bindings/bindings_base.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_base.ts
@@ -96,6 +96,7 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
         this._initPromise = null;
         // Remove own progress callback
         this.onInstantiationProgress = this.onInstantiationProgress.filter(x => x != onProgress);
+        (globalThis as any).DUCKDB_BINDINGS = this;
         return this;
     }
     /** Open a database with a config */


### PR DESCRIPTION
To let DuckDB extensions access the main module, we would need to have an access to the `DuckDBBindings` somehow.

This PR exposes them under `DUCKDB_BINDINGS` (to be consistent with `DUCKDB_RUNTIME` that is also exposed)

Let me know if you think this exposes too much, I can try to think of other way to achieve this too, though this would be by far the simplest and most flexible solution :-)