### PR TITLE
Update script to depend on globstar

### DIFF
--- a/scripts/build_loadable.sh
+++ b/scripts/build_loadable.sh
@@ -8,13 +8,11 @@ PROJECT_ROOT="$(cd $(dirname "$BASH_SOURCE[0]") && cd .. && pwd)" &> /dev/null
 
 mkdir -p loadable_extensions
 shopt -s nullglob
-shopt -s globstar
 
-FILES="build/$1/$2/**/*.duckdb_extension"
-for f in $FILES
+for f in `find ./build/$1/$2 -name '*.duckdb_extension'`
 do
         ext=`basename $f .duckdb_extension`
-        echo $ext
+        echo "Building '$ext'..."
         emcc $f -sSIDE_MODULE=1 -o loadable_extensions/$ext.duckdb_extension.wasm -O3
 done
 


### PR DESCRIPTION
Running the `scripts/build_loadable.sh` script on MacOS returns the following error:

```
./scripts/build_loadable.sh: line 11: shopt: globstar: invalid shell option name
```

This PR fixes it.