### PR TITLE
Add stub signatures

### DIFF
--- a/lib/js-stubs.js
+++ b/lib/js-stubs.js
@@ -1,55 +1,72 @@
-mergeInto(LibraryManager.library, {
+addToLibrary({
+    duckdb_web_test_platform_feature__sig: 'ii',
     duckdb_web_test_platform_feature: function (feature) {
         return globalThis.DUCKDB_RUNTIME.testPlatformFeature(Module, feature);
     },
+    duckdb_web_fs_get_default_data_protocol__sig: 'i',
     duckdb_web_fs_get_default_data_protocol: function (Module) {
         return globalThis.DUCKDB_RUNTIME.getDefaultDataProtocol(Module);
     },
+    duckdb_web_fs_file_open__sig: 'pii',
     duckdb_web_fs_file_open: function (fileId, flags) {
         return globalThis.DUCKDB_RUNTIME.openFile(Module, fileId, flags);
     },
+    duckdb_web_fs_file_sync__sig: 'vi',
     duckdb_web_fs_file_sync: function (fileId) {
         return globalThis.DUCKDB_RUNTIME.syncFile(Module, fileId);
     },
+    duckdb_web_fs_file_close__sig: 'vi',
     duckdb_web_fs_file_close: function (fileId) {
         return globalThis.DUCKDB_RUNTIME.closeFile(Module, fileId);
     },
+    duckdb_web_fs_file_truncate__sig: 'vid',
     duckdb_web_fs_file_truncate: function (fileId, newSize) {
         return globalThis.DUCKDB_RUNTIME.truncateFile(Module, fileId, newSize);
     },
+    duckdb_web_fs_file_read__sig: 'iipid',
     duckdb_web_fs_file_read: function (fileId, buf, size, location) {
         return globalThis.DUCKDB_RUNTIME.readFile(Module, fileId, buf, size, location);
     },
+    duckdb_web_fs_file_write__sig: 'iipid',
     duckdb_web_fs_file_write: function (fileId, buf, size, location) {
         return globalThis.DUCKDB_RUNTIME.writeFile(Module, fileId, buf, size, location);
     },
+    duckdb_web_fs_file_get_last_modified_time__sig: 'ii',
     duckdb_web_fs_file_get_last_modified_time: function (fileId) {
         return globalThis.DUCKDB_RUNTIME.getLastFileModificationTime(Module, fileId);
     },
+    duckdb_web_fs_directory_exists__sig: 'ipi',
     duckdb_web_fs_directory_exists: function (path, pathLen) {
         return globalThis.DUCKDB_RUNTIME.checkDirectory(Module, path, pathLen);
     },
+    duckdb_web_fs_directory_create__sig: 'vpi',
     duckdb_web_fs_directory_create: function (path, pathLen) {
         return globalThis.DUCKDB_RUNTIME.createDirectory(Module, path, pathLen);
     },
+    duckdb_web_fs_directory_remove__sig: 'vpi',
     duckdb_web_fs_directory_remove: function (path, pathLen) {
         return globalThis.DUCKDB_RUNTIME.removeDirectory(Module, path, pathLen);
     },
+    duckdb_web_fs_directory_list_files__sig: 'ipi',
     duckdb_web_fs_directory_list_files: function (path, pathLen) {
         return globalThis.DUCKDB_RUNTIME.listDirectoryEntries(Module, path, pathLen);
     },
+    duckdb_web_fs_glob__sig: 'vpi',
     duckdb_web_fs_glob: function (path, pathLen) {
         return globalThis.DUCKDB_RUNTIME.glob(Module, path, pathLen);
     },
+    duckdb_web_fs_file_move__sig: 'vpipi',
     duckdb_web_fs_file_move: function (from, fromLen, to, toLen) {
         return globalThis.DUCKDB_RUNTIME.moveFile(Module, from, fromLen, to, toLen);
     },
+    duckdb_web_fs_file_exists__sig: 'ipi',
     duckdb_web_fs_file_exists: function (path, pathLen) {
         return globalThis.DUCKDB_RUNTIME.checkFile(Module, path, pathLen);
     },
     duckdb_web_fs_file_remove: function (path, pathLen) {
         return globalThis.DUCKDB_RUNTIME.removeFile(Module, path, pathLen);
     },
+    duckdb_web_udf_scalar_call__sig: 'vpipipi',
     duckdb_web_udf_scalar_call: function (funcId, descPtr, descSize, ptrsPtr, ptrsSize, response) {
         return globalThis.DUCKDB_RUNTIME.callScalarUDF(Module, funcId, descPtr, descSize, ptrsPtr, ptrsSize, response);
     },


### PR DESCRIPTION
When compiled with `-fpic` Emscripten requires JS functions called by C++ to have their signatured declared or it fails with `Assertion failed: Missing signature argument to addFunction`.

This PR is thus adding functions signatures as described [here](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#calling-javascript-functions-as-function-pointers-from-c).