### PR TITLE
fix insertCSVFromPath in README

### DIFF
--- a/packages/duckdb-wasm/README.md
+++ b/packages/duckdb-wasm/README.md
@@ -171,7 +171,7 @@ const myArray = [
 ];
 const encoder = new TextEncoder();
 const buffer = encoder.encode(myArray);
-await db().registerFileBuffer(myTableName, buffer);
+await db.registerFileBuffer(myTableName, buffer);
 await c.insertJSONFromPath(myTableName, {
   schema: 'main',
   name: 'foo',

--- a/packages/duckdb-wasm/README.md
+++ b/packages/duckdb-wasm/README.md
@@ -129,7 +129,7 @@ await Promise.all(streamInserts);
 // (interchangeable: registerFile{Text,Buffer,URL,Handle})
 await db.registerFileText(`data.csv`, '1|foo\n2|bar\n');
 // ... with typed insert options
-await db.insertCSVFromPath('data.csv', {
+await c.insertCSVFromPath('data.csv', {
     schema: 'main',
     name: 'foo',
     detect: false,


### PR DESCRIPTION
insertCSVFromPath() is a function of the connection and not the database.
Error message:
TypeError: Cannot read properties of undefined (reading 'columns')