### PR TITLE
Example using coi: thanks @jraymakers & @dengkunli

### DIFF
--- a/examples/esbuild-browser/.gitignore
+++ b/examples/esbuild-browser/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /*.wasm
 /*.js
+/*.js.map

--- a/examples/esbuild-browser/bundle.mjs
+++ b/examples/esbuild-browser/bundle.mjs
@@ -12,8 +12,35 @@ function printErr(err) {
 
 fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-mvp.wasm'), './duckdb-mvp.wasm', printErr);
 fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-eh.wasm'), './duckdb-eh.wasm', printErr);
+fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-coi.wasm'), './duckdb-coi.wasm', printErr);
 fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-browser-mvp.worker.js'), './duckdb-browser-mvp.worker.js', printErr);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-mvp.worker.js.map'),
+    './duckdb-browser-mvp.worker.js.map',
+    printErr,
+);
 fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-browser-eh.worker.js'), './duckdb-browser-eh.worker.js', printErr);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-eh.worker.js.map'),
+    './duckdb-browser-eh.worker.js.map',
+    printErr,
+);
+fs.copyFile(path.resolve(DUCKDB_DIST, 'duckdb-browser-coi.worker.js'), './duckdb-browser-coi.worker.js', printErr);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-coi.worker.js.map'),
+    './duckdb-browser-coi.worker.js.map',
+    printErr,
+);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-coi.pthread.worker.js'),
+    './duckdb-browser-coi.pthread.worker.js',
+    printErr,
+);
+fs.copyFile(
+    path.resolve(DUCKDB_DIST, 'duckdb-browser-coi.pthread.worker.js.map'),
+    './duckdb-browser-coi.pthread.worker.js.map',
+    printErr,
+);
 
 esbuild.build({
     entryPoints: ['./index.ts'],

--- a/examples/esbuild-browser/index.ts
+++ b/examples/esbuild-browser/index.ts
@@ -12,6 +12,11 @@ import * as arrow from 'apache-arrow';
                 mainModule: './duckdb-eh.wasm',
                 mainWorker: './duckdb-browser-eh.worker.js',
             },
+            coi: {
+                mainModule: './duckdb-coi.wasm',
+                mainWorker: './duckdb-browser-coi.worker.js',
+                pthreadWorker: './duckdb-browser-coi.pthread.worker.js',
+            },
         });
 
         const logger = new duckdb.ConsoleLogger();

--- a/examples/esbuild-browser/package.json
+++ b/examples/esbuild-browser/package.json
@@ -10,10 +10,12 @@
     "devDependencies": {
         "esbuild": "^0.19.5",
         "http-server": "^14.1.1",
+        "serve": "^14.2.1",
         "typescript": "^5.2.2"
     },
     "scripts": {
         "build": "node ./bundle.mjs && tsc --noEmit",
-        "server": "http-server"
+        "server": "http-server",
+        "server-coi": "serve"
     }
 }

--- a/examples/esbuild-browser/serve.json
+++ b/examples/esbuild-browser/serve.json
@@ -1,0 +1,11 @@
+{
+  "headers": [
+    {
+      "source": "*",
+      "headers": [
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
+      ]
+    }
+  ]
+}

--- a/examples/esbuild-browser/serve.json
+++ b/examples/esbuild-browser/serve.json
@@ -3,8 +3,14 @@
     {
       "source": "*",
       "headers": [
-        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
       ]
     }
   ]

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,7 +22,7 @@ if(DEFINED ENV{DUCKDB_WASM_LOADABLE_EXTENSIONS})
 endif()
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -DDUCKDB_WASM=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -DDUCKDB_WASM=1 -DFSST_MUST_ALIGN")
 
 if(DUCKDB_WASM_LOADABLE_EXTENSIONS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWASM_LOADABLE_EXTENSIONS=1 -DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT=1 -fPIC")
@@ -110,16 +110,11 @@ if(EMSCRIPTEN)
     endif()
   # Debug build
   elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-      --profiling \
-      -gsource-map \
-      --source-map-base=file://${CMAKE_BINARY_DIR}/")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
     set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} \
       -sASSERTIONS=1 \
       -sSAFE_HEAP=1 \
-      -gsource-map \
-      --source-map-base=file://${CMAKE_BINARY_DIR}/ \
-      -sSEPARATE_DWARF_URL=file://${CMAKE_BINARY_DIR}/duckdb.wasm")
+      -g")
     # ... with fast linking
     if(WASM_FAST_LINKING)
       set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -O0")


### PR DESCRIPTION
There were two independent PRs on enabling examples using COI:
* https://github.com/duckdb/duckdb-wasm/pull/1424, that was missing a bit of the pthread syncronization dance
* https://github.com/duckdb/duckdb-wasm/pull/1490, that is centered around OPFS, and this seems an orthogonal feature

I took the liberty of merging them into this PR.

Thank you both for the contribution.

I will add enabling shell as a follow up.