### PR TITLE
Save queries in url hash segment, and restore them at startup

### DIFF
--- a/packages/duckdb-wasm-shell/crate/src/prompt_buffer.rs
+++ b/packages/duckdb-wasm-shell/crate/src/prompt_buffer.rs
@@ -437,7 +437,7 @@ impl PromptBuffer {
                                 self.output_buffer,
                                 "{reset}{fg}{bold}",
                                 reset = vt100::MODES_OFF,
-                                fg = vt100::COLOR_FG_GREEN,
+                                fg = vt100::COLOR_FG_BRIGHT_YELLOW,
                                 bold = vt100::MODE_BOLD
                             )
                             .unwrap();

--- a/packages/duckdb-wasm-shell/crate/src/shell.rs
+++ b/packages/duckdb-wasm-shell/crate/src/shell.rs
@@ -1,6 +1,6 @@
 use crate::arrow_printer::{pretty_format_batches, UTF8_BORDERS_NO_HORIZONTAL};
 use crate::duckdb::{
-    AsyncDuckDB, AsyncDuckDBConnection, DataProtocol, PACKAGE_NAME, PACKAGE_VERSION, DuckDBConfig,
+    AsyncDuckDB, AsyncDuckDBConnection, DataProtocol, DuckDBConfig, PACKAGE_NAME, PACKAGE_VERSION,
 };
 use crate::key_event::{Key, KeyEvent};
 use crate::platform;
@@ -184,22 +184,18 @@ impl Shell {
             s.focus();
         });
 
-	for entry in &(*past_queries().lock().unwrap()) {
-		    Shell::with_mut(|s| {
-            s.write(&format!(
-                "{bold}{green}",
-                bold = vt100::MODE_BOLD,
-                green = vt100::COLOR_FG_BRIGHT_YELLOW
-            ));
-			s.write(entry);
-            s.write(&format!(
-                "{normal}",
-                normal = vt100::MODES_OFF
-            ));
-
-		    });
-		Self::on_sql(entry.to_string()).await;
-	}
+        for entry in &(*past_queries().lock().unwrap()) {
+            Shell::with_mut(|s| {
+                s.write(&format!(
+                    "{bold}{green}",
+                    bold = vt100::MODE_BOLD,
+                    green = vt100::COLOR_FG_BRIGHT_YELLOW
+                ));
+                s.write(entry);
+                s.write(&format!("{normal}", normal = vt100::MODES_OFF));
+            });
+            Self::on_sql(entry.to_string()).await;
+        }
 
         Ok(())
     }
@@ -848,14 +844,13 @@ impl Shell {
 
     /// Pass information on init queries
     pub async fn pass_init_queries(queries: Vec<String>) -> Result<(), js_sys::Error> {
-
         let mut h = VecDeque::with_capacity(queries.len());
         for entry in &queries[0..queries.len()] {
             h.push_back(entry.clone());
         }
-            *past_queries().lock().unwrap() = h;
+        *past_queries().lock().unwrap() = h;
         Ok(())
-	}
+    }
 
     /// Flush output buffer to the terminal
     pub fn flush(&mut self) {

--- a/packages/duckdb-wasm-shell/crate/src/shell_api.rs
+++ b/packages/duckdb-wasm-shell/crate/src/shell_api.rs
@@ -81,6 +81,13 @@ pub fn load_history(history: &js_sys::Array, cursor: usize) {
     Shell::load_history(h, cursor);
 }
 
+#[wasm_bindgen(js_name = "passInitQueries")]
+pub async fn pass_init_queries(queries: &js_sys::Array) -> Result<(), js_sys::Error> {
+    let q: Vec<String> = queries.iter().map(|ref v| v.as_string().unwrap()).collect();
+    Shell::pass_init_queries(q).await?;
+    Ok(())
+}
+
 #[wasm_bindgen(js_name = "configureDatabase")]
 pub async fn configure_database(db: JsAsyncDuckDB) -> Result<(), js_sys::Error> {
     Shell::configure_database(AsyncDuckDB::from_bindings(db)).await?;

--- a/packages/duckdb-wasm-shell/src/shell.ts
+++ b/packages/duckdb-wasm-shell/src/shell.ts
@@ -52,7 +52,7 @@ class ShellRuntime {
     }
     public async pushInputToHistory(this: ShellRuntime, value: string) {
 	var hash = window.location.hash;
-	const encode = btoa(value);
+	const encode = encodeURIComponent(extraswaps(value));
 	if (hash === "")
 		hash = "queries=v0";
 	hash += ",";
@@ -75,6 +75,24 @@ function formatBytes(value: number): string {
     const exp = (Math.log(value) / Math.log(multiple)) | 0;
     const size = Number((value / Math.pow(multiple, exp)).toFixed(2));
     return `${size} ${exp ? `${k}MGTPEZY`[exp - 1] + suffix : `byte${size !== 1 ? 's' : ''}`}`;
+}
+
+function extraswaps(input: string): string {
+    // As long as this function is symmetrical, all good
+    let res : string = "";
+    for (let i=0; i<input.length; i++) {
+	if (input[i] == ' ')
+		res += '-';
+	else if (input[i] == '-')
+		res += ' ';
+	else if (input[i] == ';')
+		res += '~';
+	else if (input[i] == '~')
+		res += ';';
+	else
+		res += input[i];
+	}
+	return res;
 }
 
 export async function embed(props: ShellProps) {
@@ -128,7 +146,7 @@ export async function embed(props: ShellProps) {
 	var splits = hash.split(',');
 	var sqls : Array<string> = [];
 	for (var i=1; i< splits.length; i++) {
-		sqls.push( atob(splits[i]));
+		sqls.push(extraswaps(decodeURIComponent(splits[i])));
 		}
 	window.location.hash="";
     await step('Rewinding history!', async () => {

--- a/packages/duckdb-wasm-shell/src/shell.ts
+++ b/packages/duckdb-wasm-shell/src/shell.ts
@@ -51,6 +51,13 @@ class ShellRuntime {
         return await navigator.clipboard.writeText(value);
     }
     public async pushInputToHistory(this: ShellRuntime, value: string) {
+	var hash = window.location.hash;
+	const encode = btoa(value);
+	if (hash === "")
+		hash = "queries=v0";
+	hash += ",";
+	hash += encode;
+	window.location.hash = hash
         this.history.push(value);
     }
 }
@@ -116,5 +123,15 @@ export async function embed(props: ShellProps) {
     });
     await step('Attaching Shell', async () => {
         shell.configureDatabase(runtime.database);
+    });
+	var hash = window.location.hash;
+	var splits = hash.split(',');
+	var sqls : Array<string> = [];
+	for (var i=1; i< splits.length; i++) {
+		sqls.push( atob(splits[i]));
+		}
+	window.location.hash="";
+    await step('Rewinding history!', async () => {
+        shell.passInitQueries(sqls);
     });
 }

--- a/packages/duckdb-wasm-shell/src/shell.ts
+++ b/packages/duckdb-wasm-shell/src/shell.ts
@@ -20,6 +20,7 @@ class ShellRuntime {
     database: duckdb.AsyncDuckDB | null;
     history: HistoryStore;
     resizeHandler: (_event: UIEvent) => void;
+    hash: string;
 
     constructor(protected container: HTMLDivElement) {
         this.database = null;
@@ -28,6 +29,7 @@ class ShellRuntime {
             const rect = container.getBoundingClientRect();
             shell.resize(rect.width, rect.height);
         };
+        this.hash = "";
     }
 
     public async pickFiles(this: ShellRuntime): Promise<number> {
@@ -51,13 +53,11 @@ class ShellRuntime {
         return await navigator.clipboard.writeText(value);
     }
     public async pushInputToHistory(this: ShellRuntime, value: string) {
-	var hash = window.location.hash;
 	const encode = encodeURIComponent(extraswaps(value));
-	if (hash === "")
-		hash = "queries=v0";
-	hash += ",";
-	hash += encode;
-	window.location.hash = hash
+	if (this.hash === "")
+		this.hash = "queries=v0";
+	this.hash += ",";
+	this.hash += encode;
         this.history.push(value);
     }
 }
@@ -142,13 +142,12 @@ export async function embed(props: ShellProps) {
     await step('Attaching Shell', async () => {
         shell.configureDatabase(runtime.database);
     });
-	var hash = window.location.hash;
-	var splits = hash.split(',');
-	var sqls : Array<string> = [];
-	for (var i=1; i< splits.length; i++) {
+	const hash = window.location.hash;
+	const splits = hash.split(',');
+	const sqls : Array<string> = [];
+	for (let i=1; i< splits.length; i++) {
 		sqls.push(extraswaps(decodeURIComponent(splits[i])));
 		}
-	window.location.hash="";
     await step('Rewinding history!', async () => {
         shell.passInitQueries(sqls);
     });

--- a/packages/duckdb-wasm-shell/src/shell.ts
+++ b/packages/duckdb-wasm-shell/src/shell.ts
@@ -58,6 +58,8 @@ class ShellRuntime {
 		this.hash = "queries=v0";
 	this.hash += ",";
 	this.hash += encode;
+	if (window.location.hash.startsWith("#savequeries"))
+		window.location.hash = "savequeries&" + this.hash;
         this.history.push(value);
     }
 }


### PR DESCRIPTION
Idea is as follow:

Whenever a query is complete, it's stringified and it's representation it's appended to the hash segment of the URL.

If you are accessing a link like shell.duckdb.org/#queries=v0,string1,string2,string3 then the three queries encoded by those three string will be first executed, and then CLI returns control to user.

Demo is here:
https://carlopi.github.io/public-test-duckdb-wasm-spatial/#queries=v0,TE9BRCB0cGNoOw==,U0VMRUNUICdXYWl0IGZvciBhYm91dCAxMCBzZWNvbmRzLi4uJyBhcyBzdWdnZXN0aW9uOw==,Q0FMTCBkYmdlbihzZj0xKTs=,REVTQ1JJQkU7

Idea is allow ease of share URLs that directly encode significant examples. Both for us and for users.

Potential improvements:
- [ ] highlighter support
- [x] Add back a way for obtain this data, currently only read part is properly exposed
- [X] better encoding than BTOA <-> ATOB

Does this makes sense to be exposed?