### PR TITLE
Fix for emscripten 3.1.51

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ compile_commands.json
 data/tpch/**/*.parquet
 .idea
 lib/.idea
+
+check_duckdb
+wasm_setup
+loadable_extensions/*.wasm

--- a/packages/duckdb-wasm/bundle.mjs
+++ b/packages/duckdb-wasm/bundle.mjs
@@ -4,6 +4,7 @@ import path from 'path';
 import { rimrafSync } from 'rimraf';
 import mkdir from 'make-dir';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 
 // -------------------------------
 // Current bundling strategy
@@ -195,6 +196,10 @@ fs.copyFile(path.resolve(src, 'bindings', 'duckdb-coi.wasm'), path.resolve(dist,
     });
 
     console.log('[ ESBUILD ] duckdb-browser-coi.worker.js');
+    // Don't attempt to bundle NodeJS modules in the browser build.
+    execSync(
+        `sed -i.bak 's/require("vm")/["vm"].map(require)/g' ./src/bindings/duckdb-coi.pthread.js && rm ./src/bindings/duckdb-coi.pthread.js.bak`,
+    );
     await esbuild.build({
         entryPoints: ['./src/targets/duckdb-browser-coi.worker.ts'],
         outfile: 'dist/duckdb-browser-coi.worker.js',


### PR DESCRIPTION
The latest Emscripten version ([3.1.51](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3151---121323)) seem to have broken the build with:

```
Could not resolve "vm"

    src/bindings/duckdb-coi.pthread.js:1:357:
      1 │ ...=require("fs");var vm=require("vm");Object.assign(global,{self:g...
        ╵                                  ~~~~

  The package "vm" wasn't found on the file system but is built into node. Are you trying to bundle for node? You can use "platform: 'node'" to do that, which will remove this error.

/home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:1650
  let error = new Error(text);
              ^

Error: Build failed with 1 error:
src/bindings/duckdb-coi.pthread.js:1:357: ERROR: Could not resolve "vm"
    at failureErrorWithLog (/home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:1650:15)
    at /home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:1059:25
    at /home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:1004:52
    at buildResponseToResult (/home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:1057:7)
    at /home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:1086:16
    at responseCallbacks.<computed> (/home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:703:9)
    at handleIncomingPacket (/home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:763:9)
    at Socket.readFromStdout (/home/runner/work/mono/mono/hatchling/client/wasm/duckdb-wasm/node_modules/esbuild/lib/main.js:679:7)
    at Socket.emit (node:events:514:28)
    at addChunk (node:internal/streams/readable:5[45](https://github.com/motherduckdb/mono/actions/runs/7208649622/job/19639532649#step:13:46):12) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}
```

cf. this [build](https://github.com/duckdb/duckdb-wasm/actions/runs/7210471199/job/19644493777?pr=1530)

This fails is because ESBuild attempts to bundle the NodeJS package `vm`. The proposed fix is to make it invisible to ESBuild by replacing `require('vm')` with `['vm'].map(require)`, which ESBuild doesn't statically analyze and replace.