### PR TITLE
Patch all bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ lib/.idea
 
 check_duckdb
 wasm_setup
-loadable_extensions/*.wasm
+loadable_extensions


### PR DESCRIPTION
Now that `node` is an Emscripten environment, we need to patch all JS bindings to be able to run ESbuild bundling with DuckDB WASM build with loadable extension mode.