### PR TITLE
fix unit tests

### DIFF
--- a/duckdb.patch
+++ b/duckdb.patch
@@ -1,23 +1,3 @@
-diff --git a/src/function/table/system/test_all_types.cpp b/src/function/table/system/test_all_types.cpp
-index a0b856266c..753fd6323b 100644
---- a/src/function/table/system/test_all_types.cpp
-+++ b/src/function/table/system/test_all_types.cpp
-@@ -204,13 +204,14 @@ vector<TestType> TestAllTypesFun::GetTestTypes(bool use_large_enum) {
- 	auto max_map_value = Value::MAP(ListType::GetChildType(map_type), map_values);
- 	result.emplace_back(map_type, "map", std::move(min_map_value), std::move(max_map_value));
- 
-+#if 0
- 	// union
- 	child_list_t<LogicalType> members = {{"name", LogicalType::VARCHAR}, {"age", LogicalType::SMALLINT}};
- 	auto union_type = LogicalType::UNION(members);
- 	const Value &min = Value::UNION(members, 0, Value("Frank"));
- 	const Value &max = Value::UNION(members, 1, Value::SMALLINT(5));
- 	result.emplace_back(union_type, "union", min, max);
--
-+#endif
- 	return result;
- }
- 
 diff --git a/src/main/extension/extension_load.cpp b/src/main/extension/extension_load.cpp
 index 80d24c2982..2c062a98ff 100644
 --- a/src/main/extension/extension_load.cpp

--- a/lib/test/all_types_test.cc
+++ b/lib/test/all_types_test.cc
@@ -187,7 +187,7 @@ shared_ptr<arrow::Array> GetExpectedUnionArray() {
 
     auto i16_builder = std::make_shared<arrow::Int16Builder>();
     union_builder->AppendChild(i16_builder, "age");
-    
+
     (void)union_builder->Append(0);
     (void)str_builder->Append("Frank"s);
     (void)i16_builder->AppendNull();

--- a/lib/test/all_types_test.cc
+++ b/lib/test/all_types_test.cc
@@ -10,6 +10,7 @@
 #include "arrow/array/builder_dict.h"
 #include "arrow/array/builder_nested.h"
 #include "arrow/array/builder_primitive.h"
+#include "arrow/array/builder_union.h"
 #include "arrow/buffer.h"
 #include "arrow/io/memory.h"
 #include "arrow/ipc/reader.h"
@@ -178,6 +179,28 @@ shared_ptr<arrow::Array> GetExpectedMapArray() {
     return map_array_builder->Finish().ValueOrDie();
 }
 
+shared_ptr<arrow::Array> GetExpectedUnionArray() {
+    auto union_builder = std::make_shared<arrow::SparseUnionBuilder>(arrow::default_memory_pool());
+
+    auto str_builder = std::make_shared<arrow::StringBuilder>();
+    union_builder->AppendChild(str_builder, "name");
+
+    auto i16_builder = std::make_shared<arrow::Int16Builder>();
+    union_builder->AppendChild(i16_builder, "age");
+    
+    (void)union_builder->Append(0);
+    (void)str_builder->Append("Frank"s);
+    (void)i16_builder->AppendNull();
+
+    (void)union_builder->Append(1);
+    (void)str_builder->AppendNull();
+    (void)i16_builder->Append(5);
+
+    (void)union_builder->AppendNull();
+
+    return union_builder->Finish().ValueOrDie();
+}
+
 vector<string> SUPPORTED_TYPES = {"bool",
                                   "tinyint",
                                   "smallint",
@@ -209,7 +232,8 @@ vector<string> SUPPORTED_TYPES = {"bool",
                                   "dec_18_6",
                                   "dec38_10",
                                   "blob",
-                                  "bit"};
+                                  "bit",
+                                  "union"};
 
 vector<string> UNSUPPORTED_TYPES = {
     // Does not work full range as it overflows during multiplication
@@ -334,5 +358,6 @@ TEST(AllTypesTest, FullRangeTypes) {
     AssertArraysMatch(batch->GetColumnByName("struct_of_arrays"), GetExpectedStructOfArrayArray());
     AssertArraysMatch(batch->GetColumnByName("array_of_structs"), GetExpectedArrayOfStructsArray());
     AssertArraysMatch(batch->GetColumnByName("map"), GetExpectedMapArray());
+    AssertArraysMatch(batch->GetColumnByName("union"), GetExpectedUnionArray());
 }
 }  // namespace

--- a/packages/duckdb-wasm/test/all_types.test.ts
+++ b/packages/duckdb-wasm/test/all_types.test.ts
@@ -80,7 +80,7 @@ const FULLY_IMPLEMENTED_ANSWER_MAP: AnswerObjectType = {
     // Note that we multiply by thousand (and add 999 for the max) because the value returned by DuckDB is in microseconds,
     // whereas the Date object is in milliseconds.
     time: [BigInt(0), BigInt(new Date('1970-01-01T23:59:59.999+00:00').valueOf()) * BigInt(1000) + BigInt(999), null],
-    interval: [new Int32Array([0,0]),  new Int32Array([0,0]), null],
+    interval: [new Int32Array([0, 0]), new Int32Array([0, 0]), null],
 
     float: [-3.4028234663852886e38, 3.4028234663852886e38, null],
     double: [-1.7976931348623157e308, 1.7976931348623157e308, null],
@@ -112,6 +112,8 @@ const FULLY_IMPLEMENTED_ANSWER_MAP: AnswerObjectType = {
         Uint8Array.from([0, 0, 0, 97]),
         null,
     ],
+
+    union: ['Frank', 5, null],
 };
 
 // Replacements for the values we knowingly don't support from the test_all_types query
@@ -215,22 +217,19 @@ export function testAllTypes(db: () => duckdb.DuckDBBindings): void {
                 }
                 for (let i = 0; i < results.numCols; i++) {
                     const name = results.schema.fields[i].name;
-                    if (name == "bit")
-                        continue;
+                    if (name == 'bit') continue;
                     const col = results.getChildAt(i);
                     if (skip.get(name)) continue;
                     expect(col).not.toBeNull();
                     expect(col?.length).not.toEqual(0);
 
                     expect(unpack(getValue(col!.get(0))))
-                       .withContext(name)
-                       .toEqual(test.answerMap[name][0]); // Min
+                        .withContext(name)
+                        .toEqual(test.answerMap[name][0]); // Min
                     expect(unpack(getValue(col!.get(1))))
-                       .withContext(name)
-                       .toEqual(test.answerMap[name][1]); // Max
-                    expect(col!.get(2))
-                       .withContext(name)
-                       .toEqual(test.answerMap[name][2]); // Null
+                        .withContext(name)
+                        .toEqual(test.answerMap[name][1]); // Max
+                    expect(col!.get(2)).withContext(name).toEqual(test.answerMap[name][2]); // Null
                 }
             });
         }
@@ -267,8 +266,7 @@ export function testAllTypesAsync(db: () => duckdb.AsyncDuckDB): void {
                 }
                 for (let i = 0; i < results.numCols; i++) {
                     const name = results.schema.fields[i].name;
-                    if (name == "bit")
-                        continue;
+                    if (name == 'bit') continue;
                     const col = results.getChildAt(i);
                     if (skip.get(name)) continue;
                     expect(col).not.toBeNull();

--- a/scripts/generate_tpch_duckdb.sh
+++ b/scripts/generate_tpch_duckdb.sh
@@ -26,6 +26,8 @@ mkdir -p ${TPCH_SF_OUT_DUCKDB}
 
 cat << END >${DUCKDB_SCRIPT_FILE}
 .open ${TPCH_SF_OUT_DUCKDB_DB}
+install tpch;
+load tpch;
 call dbgen(sf = ${SCALE_FACTOR});
 checkpoint;
 .databases


### PR DESCRIPTION
A few unit tests were consistently failing for me locally. This should fix them.

The all_types test was missing the "union" type, which was recently added to `test_all_types()`.
(The other changes to this file are automatic formatting fixes applied by VS Code according to the settings in the repo.)

A few tests relied on generated TPCH files. The generation script was failing because it didn't load the (newly loadable) `tpch` extension. I added the appropriate "install" and "load" commands to this script.