### PR TITLE
Allow to specify bundle

### DIFF
--- a/packages/react-duckdb/src/platform_provider.tsx
+++ b/packages/react-duckdb/src/platform_provider.tsx
@@ -25,8 +25,12 @@ export const DuckDBPlatform: React.FC<PlatformProps> = (props: PlatformProps) =>
         if (inFlight.current) return await inFlight.current;
         inFlight.current = (async () => {
             try {
+                const params = new URLSearchParams(window.location.search);
+                const bundleName = params.get('bundle') as keyof duckdb.DuckDBBundles | null;
                 setBundle(b => b.updateRunning());
-                const next = await duckdb.selectBundle(props.bundles);
+
+                const bundle = bundleName !== null ? props.bundles[bundleName] : null;
+                const next = (bundle || (await duckdb.selectBundle(props.bundles))) as duckdb.DuckDBBundle;
                 inFlight.current = null;
                 setBundle(b => b.completeWith(next));
                 return next;


### PR DESCRIPTION
While developing, I found it convenient to be able to switch from one bundle to another using the `bundle` query parameter, so I thought I would contribute it.

It can be used in the Shell like this for example:
http://127.0.0.1:8081/?bundle=mvp
http://127.0.0.1:8081/?bundle=eh

Happy to adjust the implementation if need be.
