### PR TITLE
Clean-up JavaScript from unneeded exported functions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -158,7 +158,7 @@ else()
 endif()
 
 if (DUCKDB_WASM_LOADABLE_EXTENSIONS)
-  set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -s MAIN_MODULE=1 -s  -s EXPORT_ALL=1 -s FILESYSTEM=1 -s ENVIRONMENT='web,node,worker' -s ALLOW_TABLE_GROWTH -lembind")
+  set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -s MAIN_MODULE=1 -s FILESYSTEM=1 -s ENVIRONMENT='web,node,worker' -s ALLOW_TABLE_GROWTH -lembind")
 else()
   set(WASM_LINK_FLAGS "${WASM_LINK_FLAGS} -s FILESYSTEM=0 -s ENVIRONMENT='web,node,worker'")
 endif()

--- a/scripts/wasm_build_lib.sh
+++ b/scripts/wasm_build_lib.sh
@@ -65,6 +65,10 @@ emmake make \
     -j${CORES} \
     duckdb_wasm
 
+npm install -g js-beautify
+js-beautify ${BUILD_DIR}/duckdb_wasm.js > ${BUILD_DIR}/beauty.js
+awk '!(/var .*wasmExports\[/) || /var _duckdb_web/ || /var _main/ || /var _malloc/ || /var _free/ || /stack/' ${BUILD_DIR}/beauty.js > ${BUILD_DIR}/duckdb_wasm.js
+
 cp ${BUILD_DIR}/duckdb_wasm.wasm ${DUCKDB_LIB_DIR}/duckdb${SUFFIX}.wasm
 sed \
   -e "s/duckdb_wasm\.wasm/.\/duckdb${SUFFIX}.wasm/g" \


### PR DESCRIPTION
This drastically reduce the size of the generated JavaScript worker code, from 45M uncompressed to 2M, and reduces also the time spent processing the JS file and creating a bunch of (unnecessary) wrappers.

Problem is connected to dynamic loading of extensions, since I haven't found a proper way to express "symbol should be available to other dlopen-ed modules BUT it's not needed on the JavaScript side".

I am not sure whether this is a current Emscripten limitation or if the compiler wrapper should be invoked in a different way.

Current solution is blunt and exploit current Emscripten specifics code-generation around `var wasmExports = createWasm();`. This needs to be reworked to be compatible with future versions.

Basically before this PR for any symbol exported at the C++ level a function like:
```
var __function_name = Module["__function_name"] = (a0) => (__function_name = Module["__function_name"] = wasmExports["_function_name"])(a0);
```
would be generated.

Multiplied 80K symbols, it meant a lot of JavaScript code had to be downloaded, parsed and executed for no actual use.

This should solve https://github.com/duckdb/duckdb-wasm/issues/1561, but I will have to properly check after this gets merged.

This adds a (compile-time) dependency on awk (that should be widely available) and on the npm module js-beautify.