### PR TITLE
Clean-up JavaScript from unneeded exported globals

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1049,6 +1049,10 @@ jobs:
                   name: duckdb-wasm-packages-loadable
                   path: duckdb-wasm-packages.zip
 
+            - name: Measure NPM stats
+              run: |
+                  ./scripts/npm_measure_lib.sh
+
             - name: Publish to NPM
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/scripts/npm_measure_lib.sh
+++ b/scripts/npm_measure_lib.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PROJECT_ROOT="$(cd $(dirname "$BASH_SOURCE[0]") && cd .. && pwd)" &> /dev/null
+
+cd ${PROJECT_ROOT}/packages/duckdb-wasm
+mkdir -p ./dist/img
+cp ${PROJECT_ROOT}/misc/duckdb.svg ./dist/img/duckdb.svg
+cp ${PROJECT_ROOT}/misc/duckdb_wasm.svg ./dist/img/duckdb_wasm.svg
+${PROJECT_ROOT}/scripts/build_duckdb_badge.sh > ./dist/img/duckdb_version_badge.svg
+
+npm install -g pkg-size
+pkg-size .

--- a/scripts/wasm_build_lib.sh
+++ b/scripts/wasm_build_lib.sh
@@ -67,7 +67,7 @@ emmake make \
 
 npm install -g js-beautify
 js-beautify ${BUILD_DIR}/duckdb_wasm.js > ${BUILD_DIR}/beauty.js
-awk '!(/var .*wasmExports\[/) || /var _duckdb_web/ || /var _main/ || /var _malloc/ || /var _free/ || /stack/' ${BUILD_DIR}/beauty.js > ${BUILD_DIR}/duckdb_wasm.js
+awk '!(/var .*wasmExports\[/ || /var [_a-z0-9A-Z]+ = Module\[\"[_a-z0-9A-Z]+\"\] = [0-9]+;/) || /var _duckdb_web/ || /var _main/ || /var _malloc/ || /var _free/ || /var stack/' ${BUILD_DIR}/beauty.js > ${BUILD_DIR}/duckdb_wasm.js
 
 cp ${BUILD_DIR}/duckdb_wasm.wasm ${DUCKDB_LIB_DIR}/duckdb${SUFFIX}.wasm
 sed \


### PR DESCRIPTION
Follow up of https://github.com/duckdb/duckdb-wasm/pull/1589, now avoiding more unnecessary code by filtering for exported C++ globals to JavaScript.

duckdb-worker-eh.js goes from 2.0M to 1.2M.

Also add attempt at measuring package size via pkg-size npm package.

Then using your favourite DBMS:
```
npx pkg-size --sizes=size --json > pkg-sizes.json
duckdb -c "select sum (size) from (select unnest(f) from (select unnest(files) as f from read_json_auto('pkg-sizes.json')));"
duckdb -c "select sum (size), sum(size) < '150000000' from (select unnest(f) from (select unnest(files) as f from read_json_auto('pkg-sizes.json')));"
```
would allow to have the measurement summed up.

There has to be a more proper way of measuring sizes by first building a local package, installing it elsewhere and checking the content, I will have to look into that.