### PR TITLE
Remove unused imports to prevent TS errors

### DIFF
--- a/packages/react-duckdb/src/connection_provider.tsx
+++ b/packages/react-duckdb/src/connection_provider.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import * as imm from 'immutable';
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { useDuckDB, useDuckDBResolver } from './database_provider';
-import { ResolvableStatus } from './resolvable';
 
 type DialerFn = (id?: number) => void;
 

--- a/packages/react-duckdb/src/database_provider.tsx
+++ b/packages/react-duckdb/src/database_provider.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import * as duckdb from '@duckdb/duckdb-wasm';
-import { useDuckDBLogger, useDuckDBBundle, useDuckDBBundleResolver } from './platform_provider';
-import { Resolvable, Resolver, ResolvableStatus } from './resolvable';
+import { useDuckDBLogger, useDuckDBBundleResolver } from './platform_provider';
+import { Resolvable, Resolver } from './resolvable';
 
 const setupCtx = React.createContext<Resolvable<duckdb.AsyncDuckDB, duckdb.InstantiationProgress> | null>(null);
 const resolverCtx = React.createContext<Resolver<duckdb.AsyncDuckDB> | null>(null);

--- a/packages/react-duckdb/src/platform_provider.tsx
+++ b/packages/react-duckdb/src/platform_provider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as duckdb from '@duckdb/duckdb-wasm';
-import { Resolvable, Resolver, ResolvableStatus } from './resolvable';
+import { Resolvable, Resolver } from './resolvable';
 
 type PlatformProps = {
     children: React.ReactElement | React.ReactElement[];


### PR DESCRIPTION
This PR removes unused imports which cause TA errors, like this:

```
node_modules/@duckdb/react-duckdb/src/connection_provider.tsx:5:1 - error TS6133: 'ResolvableStatus' is declared but its value is never read.

5 import { ResolvableStatus } from './resolvable';
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@duckdb/react-duckdb/src/database_provider.tsx:3:27 - error TS6133: 'useDuckDBBundle' is declared but its value is never read.

3 import { useDuckDBLogger, useDuckDBBundle, useDuckDBBundleResolver } from './platform_provider';
                            ~~~~~~~~~~~~~~~

node_modules/@duckdb/react-duckdb/src/database_provider.tsx:4:32 - error TS6133: 'ResolvableStatus' is declared but its value is never read.

4 import { Resolvable, Resolver, ResolvableStatus } from './resolvable';
                                 ~~~~~~~~~~~~~~~~

node_modules/@duckdb/react-duckdb/src/platform_provider.tsx:3:32 - error TS6133: 'ResolvableStatus' is declared but its value is never read.

3 import { Resolvable, Resolver, ResolvableStatus } from './resolvable';
                                 ~~~~~~~~~~~~~~~~


Found 4 errors in 3 files.

Errors  Files
     1  node_modules/@duckdb/react-duckdb/src/connection_provider.tsx:5
     2  node_modules/@duckdb/react-duckdb/src/database_provider.tsx:3
     1  node_modules/@duckdb/react-duckdb/src/platform_provider.tsx:3
```

This is a problem even with `"skipLibCheck": true` likely due to https://github.com/microsoft/TypeScript/issues/40426