### PR TITLE
Rework targets, introducing `make serve` or `make serve_local`

### DIFF
--- a/.github/config/extension_config_wasm.cmake
+++ b/.github/config/extension_config_wasm.cmake
@@ -22,11 +22,8 @@ duckdb_extension_load(sqlite_scanner
         GIT_TAG 078cd16fbd9a4ff96a71c6f5aafc27343e087cbb
         )
 
-################ SUBSTRAIT
-if (NOT WIN32)
-    duckdb_extension_load(substrait
-            LOAD_TESTS DONT_LINK
-            GIT_URL https://github.com/duckdb/substrait
-            GIT_TAG e75ba6a9a43d75d8c72ecc38e6f751fd8e3474a0
-            )
-endif()
+duckdb_extension_load(substrait
+	LOAD_TESTS DONT_LINK
+	GIT_URL https://github.com/duckdb/substrait
+	GIT_TAG e75ba6a9a43d75d8c72ecc38e6f751fd8e3474a0
+	)

--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,7 @@ build_loadable_unsigned:
 serve_loadable: wasmpack shell docs
 	yarn workspace @duckdb/duckdb-wasm-app build:release
 	mkdir -p packages/duckdb-wasm-app/build/release/duckdb-wasm/${DUCKDB_HASH}/wasm_eh/
-	cp loadable_extensions/relsize/eh/* packages/duckdb-wasm-app/build/release/duckdb-wasm/${DUCKDB_HASH}/wasm_eh/.
+	cp -r build/extension_repository packages/duckdb-wasm-app/build/release/.
 	http-server packages/duckdb-wasm-app/build/release -o
 
 .PHONY: app_server

--- a/Makefile
+++ b/Makefile
@@ -369,10 +369,17 @@ build_loadable_unsigned:
 	DUCKDB_WASM_LOADABLE_EXTENSIONS="unsigned" GEN=ninja ./scripts/wasm_build_lib.sh relsize eh
 	bash ./scripts/build_loadable.sh relsize eh
 
-serve_loadable: wasmpack shell docs
+serve_loadable_base: wasmpack shell docs
 	yarn workspace @duckdb/duckdb-wasm-app build:release
 	mkdir -p packages/duckdb-wasm-app/build/release/duckdb-wasm/${DUCKDB_HASH}/wasm_eh/
 	cp -r build/extension_repository packages/duckdb-wasm-app/build/release/.
+
+.PHONY: serve_local
+serve_local: build_loadable_unsigned serve_loadable_base
+	http-server packages/duckdb-wasm-app/build/release -o "#queries=v0,SET-custom_extension_repository%3D'http%3A%2F%2F127.0.0.1%3A8080%2Fextension_repository'~" -a 127.0.0.1 -p 8080
+
+.PHONY: serve
+serve: build_loadable serve_loadable_base
 	http-server packages/duckdb-wasm-app/build/release -o
 
 .PHONY: app_server

--- a/lib/cmake/duckdb.cmake
+++ b/lib/cmake/duckdb.cmake
@@ -26,6 +26,7 @@ ExternalProject_Add(
   INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/duckdb/install"
   CMAKE_ARGS -G${CMAKE_GENERATOR}
              -DCMAKE_CXX_STANDARD=17
+             -DLOCAL_EXTENSION_REPO="../../build/extension_repository"
              -DCMAKE_CXX_FLAGS=${DUCKDB_CXX_FLAGS}
              -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
              -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}


### PR DESCRIPTION
`make serve` will build with the same defaults as shell.duckdb.org, and eventually serve the equivalent content to be opened in a browser tab.

`make serve_local` will do the same with 2 major changes: unsigned extension are enabled AND custom_extension_directory is made to point to the local one (instead of the remote one).