### PR TITLE
Bump to DuckDB v0.10.1

### DIFF
--- a/duckdb.patch
+++ b/duckdb.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ea74d55f86..db27a653b3 100644
+index aebc060c3b..12611048b0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -83,6 +83,13 @@ if (EXTENSION_STATIC_BUILD AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
@@ -16,7 +16,7 @@ index ea74d55f86..db27a653b3 100644
  
  option(FORCE_COLORED_OUTPUT
         "Always produce ANSI-colored output (GNU/Clang only)." FALSE)
-@@ -762,7 +769,6 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY PARAMETERS)
+@@ -805,7 +812,6 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY PARAMETERS)
              ${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE
              "${CMAKE_BINARY_DIR}/${OUTPUT_DIRECTORY}")
    endif()
@@ -24,7 +24,7 @@ index ea74d55f86..db27a653b3 100644
    if(EMSCRIPTEN)
      # Copy file.duckdb_extension.wasm to file.duckdb_extension.wasm.lib
      add_custom_command(
-@@ -774,7 +780,7 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY PARAMETERS)
+@@ -817,7 +823,7 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY PARAMETERS)
      add_custom_command(
        TARGET ${TARGET_NAME}
        POST_BUILD
@@ -34,33 +34,34 @@ index ea74d55f86..db27a653b3 100644
    endif()
  endfunction()
 diff --git a/src/include/duckdb/main/extension_entries.hpp b/src/include/duckdb/main/extension_entries.hpp
-index 1c96337d7c..af86306bfe 100644
+index 3b84b1544e..c1037aa7b6 100644
 --- a/src/include/duckdb/main/extension_entries.hpp
 +++ b/src/include/duckdb/main/extension_entries.hpp
-@@ -209,12 +209,14 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
-     {"azure_storage_connection_string", "azure"},
+@@ -243,6 +243,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
      {"binary_as_string", "parquet"},
+     {"ca_cert_file", "httpfs"},
      {"calendar", "icu"},
 +#ifndef EMSCRIPTEN
+     {"enable_server_cert_verification", "httpfs"},
      {"force_download", "httpfs"},
-     {"http_retries", "httpfs"},
+     {"http_keep_alive", "httpfs"},
+@@ -250,6 +251,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
      {"http_retry_backoff", "httpfs"},
      {"http_retry_wait_ms", "httpfs"},
      {"http_timeout", "httpfs"},
-     {"http_keep_alive", "httpfs"},
 +#endif
-     {"pg_debug_show_queries", "postgres_scanner"},
-     {"pg_use_binary_copy", "postgres_scanner"},
-     {"pg_experimental_filter_pushdown", "postgres_scanner"},
-@@ -222,6 +224,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
-     {"pg_connection_limit", "postgres_scanner"},
-     {"pg_pages_per_task", "postgres_scanner"},
      {"pg_array_as_varchar", "postgres_scanner"},
+     {"pg_connection_cache", "postgres_scanner"},
+     {"pg_connection_limit", "postgres_scanner"},
+@@ -257,6 +259,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
+     {"pg_experimental_filter_pushdown", "postgres_scanner"},
+     {"pg_pages_per_task", "postgres_scanner"},
+     {"pg_use_binary_copy", "postgres_scanner"},
 +#ifndef EMSCRIPTEN
      {"s3_access_key_id", "httpfs"},
      {"s3_endpoint", "httpfs"},
      {"s3_region", "httpfs"},
-@@ -233,6 +236,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
+@@ -268,6 +271,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
      {"s3_url_compatibility_mode", "httpfs"},
      {"s3_url_style", "httpfs"},
      {"s3_use_ssl", "httpfs"},
@@ -68,30 +69,6 @@ index 1c96337d7c..af86306bfe 100644
      {"sqlite_all_varchar", "sqlite_scanner"},
      {"timezone", "icu"},
  }; // END_OF_EXTENSION_SETTINGS
-@@ -308,8 +312,8 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
- static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
-     //    "azure",
-     "arrow", "aws", "autocomplete", "excel", "fts", "httpfs",
--    // "inet",
--    // "icu",
-+    "inet",
-+    "icu",
-     "json", "parquet", "postgres_scanner",
-     // "spatial", TODO: table function isnt always autoloaded so test fails
-     "sqlsmith", "sqlite_scanner", "tpcds", "tpch"}; // END_OF_AUTOLOADABLE_EXTENSIONS
-diff --git a/src/main/extension/extension_install.cpp b/src/main/extension/extension_install.cpp
-index 418a298db3..e7943a95e5 100644
---- a/src/main/extension/extension_install.cpp
-+++ b/src/main/extension/extension_install.cpp
-@@ -171,7 +171,7 @@ string ExtensionHelper::ExtensionUrlTemplate(optional_ptr<const DBConfig> db_con
- 	string versioned_path = "/${REVISION}/${PLATFORM}/${NAME}.duckdb_extension";
- #ifdef WASM_LOADABLE_EXTENSIONS
- 	string default_endpoint = "https://extensions.duckdb.org";
--	versioned_path = "/duckdb-wasm" + versioned_path + ".wasm";
-+	versioned_path = versioned_path + ".wasm";
- #else
- 	string default_endpoint = "http://extensions.duckdb.org";
- 	versioned_path = versioned_path + ".gz";
 diff --git a/src/main/extension/extension_load.cpp b/src/main/extension/extension_load.cpp
 index a001f2b997..c532db1b2d 100644
 --- a/src/main/extension/extension_load.cpp
@@ -314,24 +291,3 @@ index a001f2b997..c532db1b2d 100644
  #else
  	auto dopen_from = filename;
  #endif
-diff --git a/src/parallel/task_scheduler.cpp b/src/parallel/task_scheduler.cpp
-index aad0a13360..613c856230 100644
---- a/src/parallel/task_scheduler.cpp
-+++ b/src/parallel/task_scheduler.cpp
-@@ -242,13 +242,13 @@ void TaskScheduler::SetThreads(idx_t total_threads, idx_t external_threads) {
- 	if (total_threads < external_threads) {
- 		throw SyntaxException("Number of threads can't be smaller than number of external threads!");
- 	}
--	thread_count = total_threads - external_threads;
- #else
--	if (threads.size() != external_threads) {
-+	if (total_threads != external_threads) {
- 		throw NotImplementedException(
--		    "DuckDB was compiled without threads! Setting threads != external_threads is not allowed.");
-+		    "DuckDB was compiled without threads! Setting total_threads != external_threads is not allowed.");
- 	}
- #endif
-+	thread_count = total_threads - external_threads;
- }
- 
- void TaskScheduler::SetAllocatorFlushTreshold(idx_t threshold) {

--- a/packages/duckdb-wasm/test/all_types.test.ts
+++ b/packages/duckdb-wasm/test/all_types.test.ts
@@ -156,7 +156,7 @@ function getValue(x: any): any {
 const ALL_TYPES_TEST: AllTypesTest[] = [
     {
         name: 'fully supported types',
-        query: `SELECT * EXCLUDE('uhugeint') REPLACE('not_implemented' as map) FROM test_all_types()`,
+        query: `SELECT * EXCLUDE(uhugeint, fixed_int_array, fixed_varchar_array, fixed_nested_int_array, fixed_nested_varchar_array, fixed_struct_array, struct_of_fixed_array, fixed_array_of_int_list, list_of_fixed_int_array) REPLACE('not_implemented' as map) FROM test_all_types()`,
         skip: REPLACE_COLUMNS,
         answerMap: FULLY_IMPLEMENTED_ANSWER_MAP,
         answerCount: REPLACE_COLUMNS.length + Object.keys(FULLY_IMPLEMENTED_ANSWER_MAP).length,

--- a/packages/duckdb-wasm/test/insert_csv.test.ts
+++ b/packages/duckdb-wasm/test/insert_csv.test.ts
@@ -65,9 +65,9 @@ const CSV_INSERT_TESTS: CSVInsertTest[] = [
         },
         query: 'SELECT * FROM main.foo',
         expectedColumns: [
-            { name: 'column0', values: ['a'] },
-            { name: 'column1', values: ['b'] },
-            { name: 'column2', values: ['c'] },
+            { name: 'a', values: [] },
+            { name: 'b', values: [] },
+            { name: 'c', values: [] },
         ],
     },
     {


### PR DESCRIPTION
This is currently NOT working due to:
* CSV test being too inflexible
* test_all_types test being too inflexible
* duckdb-wasm extensions are not there yet available

1 and 2 will be fixed test side, extensions to be signed/uploaded on a side.