### PR TITLE
pass DUCKDB_EXTERNAL_PLATFORM to duckdb submodule cmake

### DIFF
--- a/lib/cmake/duckdb.cmake
+++ b/lib/cmake/duckdb.cmake
@@ -45,6 +45,7 @@ ExternalProject_Add(
              -DBUILD_UNITTESTS=FALSE
              -DDISABLE_BUILTIN_EXTENSIONS=TRUE
              -DUSE_WASM_THREADS=${USE_WASM_THREADS}
+             -DDUCKDB_EXPLICIT_PLATFORM=${DUCKDB_EXPLICIT_PLATFORM}
   BUILD_BYPRODUCTS
     <INSTALL_DIR>/lib/libduckdb_re2.a
     <INSTALL_DIR>/lib/libduckdb_static.a


### PR DESCRIPTION
Build-type detection should be overridden by providing `DUCKDB_PLATFORM` (cf. https://github.com/duckdb/duckdb/blob/8ce3df950c0c6f25815ebd1dd92257a81223f618/CMakeLists.txt#L1191):
```
duckdb_platform_binary > duckdb_platform_out || (echo "Provide explicit DUCKDB_PLATFORM=your_target_arch to avoid build-type detection of the platform" && exit 1)
```

Unfortunately, although `scripts/wasm_build_lib.sh` passes `DUCKDB_EXPLICIT_PLATFORM` to cmake via `lib/CMakeLists.txt` -> `lib/cmake/duckdb.cmake`, it does not end up at `submodules/duckdb/CMakeLists.txt`.

This breaks the build when auto detection fails, e.g. because the latest (3.1.56) default emsdk node version 16.20 would still need `--experimental-wasm-eh` to execute the `duckdb_platform_binary.js`/`.wasm`.