### PR TITLE
adding logic to detect whether range requests are supported via ContentRange

### DIFF
--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -188,7 +188,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
 
                     // Try to fallback to full read?
                     if (file.allowFullHttpReads) {
-                        if (((contentLength !== null) && (+contentLength > 1)) || file.dataProtocol == DuckDBDataProtocol.S3) {
+                        {
                             // 2. Send a dummy GET range request querying the first byte of the file
                             //          -> good IFF status is 206 and contentLenght2 is 1
                             //          -> otherwise, iff 200 and contentLenght2 == contentLenght


### PR DESCRIPTION
Mostly by @carstonhernke, minor refactor to unify with follow-up logic.

Fixes https://github.com/duckdb/duckdb-wasm/issues/1367, and closes https://github.com/duckdb/duckdb-wasm/pull/1702 since it implements the same functionality.