### PR TITLE
Properly return 0 instead of emtpy return

### DIFF
--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -308,7 +308,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                     // so we need (if enabled) to bump to a ranged GET
                     if (!BROWSER_RUNTIME.getGlobalFileInfo(mod)?.allowFullHttpReads) {
                         failWith(mod, `HEAD request failed: ${path}, with full http reads are disabled`);
-                        return;
+                        return 0;
                     }
                     const xhr2 = new XMLHttpRequest();
                     if (path.startsWith('s3://')) {
@@ -322,7 +322,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                     xhr2.send(null);
                     if (xhr2.status != 200 && xhr2.status !== 206) {
                         failWith(mod, `HEAD and GET requests failed: ${path}`);
-                        return;
+                        return 0;
                     }
                     const contentLength = xhr2.getResponseHeader('Content-Length');
                     if (contentLength && (+contentLength > 1)) {


### PR DESCRIPTION
This emerged while investigating #1658, but reproduction is not deterministic so hard to say