### PR TITLE
Set duckdb_api

### DIFF
--- a/lib/src/webdb.cc
+++ b/lib/src/webdb.cc
@@ -816,6 +816,7 @@ arrow::Status WebDB::Open(std::string_view args_json) {
         db_config.options.maximum_threads = config_->maximum_threads;
         db_config.options.use_temporary_directory = false;
         db_config.options.access_mode = access_mode;
+        db_config.options.duckdb_api = "wasm";
         auto db = std::make_shared<duckdb::DuckDB>(config_->path, &db_config);
 #ifndef WASM_LOADABLE_EXTENSIONS
         duckdb_web_parquet_init(db.get());


### PR DESCRIPTION
By default, "cpp" is the fallthrough option for `duckdb_api`. This PR sets it to `wasm` instead.

Before the change:
```
┌─────────────────────────────┐
│ user_agent                  │
╞═════════════════════════════╡
│ duckdb/v0.10.2(wasm_eh) cpp │
└─────────────────────────────┘
```

After the change:
```
duckdb> pragma user_agent;
┌──────────────────────────────┐
│ user_agent                   │
╞══════════════════════════════╡
│ duckdb/v0.10.2(wasm_eh) wasm │
└──────────────────────────────┘
```
