### PR TITLE
Modify patch: Proper handling for custom_extension_repository

### DIFF
--- a/duckdb.patch
+++ b/duckdb.patch
@@ -1,15 +1,3 @@
-diff --git a/src/include/duckdb/common/enable_shared_from_this.ipp b/src/include/duckdb/common/enable_shared_from_this_ipp.hpp
-similarity index 100%
-rename from src/include/duckdb/common/enable_shared_from_this.ipp
-rename to src/include/duckdb/common/enable_shared_from_this_ipp.hpp
-diff --git a/src/include/duckdb/common/shared_ptr.ipp b/src/include/duckdb/common/shared_ptr_ipp.hpp
-similarity index 100%
-rename from src/include/duckdb/common/shared_ptr.ipp
-rename to src/include/duckdb/common/shared_ptr_ipp.hpp
-diff --git a/src/include/duckdb/common/weak_ptr.ipp b/src/include/duckdb/common/weak_ptr_ipp.hpp
-similarity index 100%
-rename from src/include/duckdb/common/weak_ptr.ipp
-rename to src/include/duckdb/common/weak_ptr_ipp.hpp
 diff --git a/extension/json/CMakeLists.txt b/extension/json/CMakeLists.txt
 index 4101111df8..3e035e80d3 100644
 --- a/extension/json/CMakeLists.txt
@@ -22,6 +10,10 @@ index 4101111df8..3e035e80d3 100644
  
  install(
    TARGETS json_extension
+diff --git a/src/include/duckdb/common/enable_shared_from_this.ipp b/src/include/duckdb/common/enable_shared_from_this_ipp.hpp
+similarity index 100%
+rename from src/include/duckdb/common/enable_shared_from_this.ipp
+rename to src/include/duckdb/common/enable_shared_from_this_ipp.hpp
 diff --git a/src/include/duckdb/common/file_open_flags.hpp b/src/include/duckdb/common/file_open_flags.hpp
 index d0509a214b..1b5107e849 100644
 --- a/src/include/duckdb/common/file_open_flags.hpp
@@ -54,6 +46,14 @@ index 6d0910ca6b..eff60e3db2 100644
  
  namespace duckdb {
  
+diff --git a/src/include/duckdb/common/shared_ptr.ipp b/src/include/duckdb/common/shared_ptr_ipp.hpp
+similarity index 100%
+rename from src/include/duckdb/common/shared_ptr.ipp
+rename to src/include/duckdb/common/shared_ptr_ipp.hpp
+diff --git a/src/include/duckdb/common/weak_ptr.ipp b/src/include/duckdb/common/weak_ptr_ipp.hpp
+similarity index 100%
+rename from src/include/duckdb/common/weak_ptr.ipp
+rename to src/include/duckdb/common/weak_ptr_ipp.hpp
 diff --git a/src/include/duckdb/main/extension_install_info.hpp b/src/include/duckdb/main/extension_install_info.hpp
 index 64b7b520a7..b03f64b3aa 100644
 --- a/src/include/duckdb/main/extension_install_info.hpp
@@ -105,20 +105,25 @@ index d188cb5dc3..d323fe9d7a 100644
  #else
  	string default_endpoint = ExtensionRepository::DEFAULT_REPOSITORY_URL;
 diff --git a/src/main/extension/extension_load.cpp b/src/main/extension/extension_load.cpp
-index 65438aa8ec..1185bccbc7 100644
+index 65438aa8ec..d85ef71c37 100644
 --- a/src/main/extension/extension_load.cpp
 +++ b/src/main/extension/extension_load.cpp
-@@ -175,7 +175,8 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
+@@ -175,7 +175,13 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
  		direct_load = false;
  		string extension_name = ApplyExtensionAlias(extension);
  #ifdef WASM_LOADABLE_EXTENSIONS
 -		string url_template = ExtensionUrlTemplate(&config, "");
 +		ExtensionRepository repository;
++
++		string custom_endpoint = config.options.custom_extension_repo;
++		if (!custom_endpoint.empty()) {
++			repository = ExtensionRepository("custom", custom_endpoint);
++		}
 +		string url_template = ExtensionUrlTemplate(&config, repository, "");
  		string url = ExtensionFinalizeUrlTemplate(url_template, extension_name);
  
  		char *str = (char *)EM_ASM_PTR(
-@@ -215,68 +216,223 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
+@@ -215,68 +221,223 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
  		direct_load = true;
  		filename = fs.ExpandPath(filename);
  	}
@@ -329,13 +334,13 @@ index 65438aa8ec..1185bccbc7 100644
 +			}
 +			ComputeSHA256String(x, &hash_chunks[i]);
 +		}
++
++		string hash_concatenation;
++		hash_concatenation.reserve(32 * numChunks); // 256 bits -> 32 bytes per chunk
  
 -		if (!signature_valid) {
 -			throw IOException(config.error_manager->FormatException(ErrorType::UNSIGNED_EXTENSION, filename) +
 -			                  metadata_mismatch_error);
-+		string hash_concatenation;
-+		hash_concatenation.reserve(32 * numChunks); // 256 bits -> 32 bytes per chunk
-+
 +		for (auto &hash_chunk : hash_chunks) {
 +			hash_concatenation += hash_chunk;
  		}
@@ -348,19 +353,19 @@ index 65438aa8ec..1185bccbc7 100644
 +
 +		for (idx_t j = 0; j < signature.size(); j++) {
 +			signature[j] = ((uint8_t *)exe)[4 + signature_offset + j];
- 		}
--	} else if (!config.options.allow_extensions_metadata_mismatch) {
--		if (!metadata_mismatch_error.empty()) {
--			// Unsigned extensions AND configuration allowing n, loading allowed, mainly for
--			// debugging purposes
--			throw InvalidInputException(metadata_mismatch_error);
++		}
 +		bool any_valid = false;
 +		for (auto &key : ExtensionHelper::GetPublicKeys()) {
 +			if (duckdb_mbedtls::MbedTlsWrapper::IsValidSha256Signature(key, signature, two_level_hash)) {
 +				any_valid = true;
 +				break;
 +			}
-+		}
+ 		}
+-	} else if (!config.options.allow_extensions_metadata_mismatch) {
+-		if (!metadata_mismatch_error.empty()) {
+-			// Unsigned extensions AND configuration allowing n, loading allowed, mainly for
+-			// debugging purposes
+-			throw InvalidInputException(metadata_mismatch_error);
 +		if (!any_valid) {
 +			throw IOException(config.error_manager->FormatException(ErrorType::UNSIGNED_EXTENSION, filename));
  		}
@@ -392,7 +397,7 @@ index 65438aa8ec..1185bccbc7 100644
  #else
  	auto dopen_from = filename;
  #endif
-@@ -294,25 +450,27 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
+@@ -294,25 +455,27 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
  	result.lib_hdl = lib_hdl;
  
  	if (!direct_load) {


### PR DESCRIPTION
Thanks @Y-- for reporting this.

Error was:
```
SET custom_extension_repository = 'https://something.else';
LOAD x;
```
would still load from default URL.