### PR TITLE
Allow to disable (or postpone) some HEAD requests to allow better testing

### DIFF
--- a/lib/include/duckdb/web/config.h
+++ b/lib/include/duckdb/web/config.h
@@ -70,7 +70,7 @@ struct DuckDBConfigOptions {
 struct FileSystemConfig {
     /// Allow falling back to full HTTP reads if the server does not support range requests
     std::optional<bool> allow_full_http_reads = std::nullopt;
-    std::optional<bool> reliableHeadRequests = std::nullopt;
+    std::optional<bool> reliable_head_requests = std::nullopt;
 };
 
 struct WebDBConfig {
@@ -88,7 +88,7 @@ struct WebDBConfig {
         .cast_decimal_to_double = std::nullopt,
     };
     /// The filesystem
-    FileSystemConfig filesystem = {.allow_full_http_reads = std::nullopt, .reliableHeadRequests = std::nullopt};
+    FileSystemConfig filesystem = {.allow_full_http_reads = std::nullopt, .reliable_head_requests = std::nullopt};
 
     /// These options are fetched from DuckDB
     DuckDBConfigOptions duckdb_config_options = {

--- a/lib/include/duckdb/web/config.h
+++ b/lib/include/duckdb/web/config.h
@@ -70,6 +70,7 @@ struct DuckDBConfigOptions {
 struct FileSystemConfig {
     /// Allow falling back to full HTTP reads if the server does not support range requests
     std::optional<bool> allow_full_http_reads = std::nullopt;
+    std::optional<bool> reliableHeadRequests = std::nullopt;
 };
 
 struct WebDBConfig {
@@ -87,7 +88,7 @@ struct WebDBConfig {
         .cast_decimal_to_double = std::nullopt,
     };
     /// The filesystem
-    FileSystemConfig filesystem = {.allow_full_http_reads = std::nullopt};
+    FileSystemConfig filesystem = {.allow_full_http_reads = std::nullopt, .reliableHeadRequests = std::nullopt};
 
     /// These options are fetched from DuckDB
     DuckDBConfigOptions duckdb_config_options = {

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -49,7 +49,7 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
                               .filesystem =
                                   FileSystemConfig{
                                       .allow_full_http_reads = std::nullopt,
-                                      .reliableHeadRequests = std::nullopt,
+                                      .reliable_head_requests = std::nullopt,
                                   },
                               .duckdb_config_options =
                                   DuckDBConfigOptions{
@@ -99,7 +99,7 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
                 config.filesystem.allow_full_http_reads = fs["allowFullHTTPReads"].GetBool();
             }
             if (fs.HasMember("reliableHeadRequests") && fs["reliableHeadRequests"].IsBool()) {
-                config.filesystem.reliableHeadRequests = fs["reliableHeadRequests"].GetBool();
+                config.filesystem.reliable_head_requests = fs["reliableHeadRequests"].GetBool();
             }
         }
     }

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -49,6 +49,7 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
                               .filesystem =
                                   FileSystemConfig{
                                       .allow_full_http_reads = std::nullopt,
+                                      .reliableHeadRequests = std::nullopt,
                                   },
                               .duckdb_config_options =
                                   DuckDBConfigOptions{
@@ -96,6 +97,9 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
             auto fs = doc["filesystem"].GetObject();
             if (fs.HasMember("allowFullHTTPReads") && fs["allowFullHTTPReads"].IsBool()) {
                 config.filesystem.allow_full_http_reads = fs["allowFullHTTPReads"].GetBool();
+            }
+            if (fs.HasMember("reliableHeadRequests") && fs["reliableHeadRequests"].IsBool()) {
+                config.filesystem.reliableHeadRequests = fs["reliableHeadRequests"].GetBool();
             }
         }
     }

--- a/lib/src/io/web_filesystem.cc
+++ b/lib/src/io/web_filesystem.cc
@@ -320,7 +320,7 @@ rapidjson::Value WebFileSystem::WebFile::WriteInfo(rapidjson::Document &doc) con
         value.AddMember("allowFullHttpReads", true, allocator);
     }
     if ((data_protocol_ == DataProtocol::HTTP || data_protocol_ == DataProtocol::S3) &&
-        filesystem_.config_->filesystem.reliableHeadRequests.value_or(true)) {
+        filesystem_.config_->filesystem.reliable_head_requests.value_or(true)) {
         value.AddMember("reliableHeadRequests", true, allocator);
     }
     value.AddMember("collectStatistics", filesystem_.file_statistics_->TracksFile(file_name_), doc.GetAllocator());
@@ -497,7 +497,7 @@ rapidjson::Value WebFileSystem::WriteGlobalFileInfo(rapidjson::Document &doc, ui
     if (config_->filesystem.allow_full_http_reads.value_or(true)) {
         value.AddMember("allowFullHttpReads", true, allocator);
     }
-    if (config_->filesystem.reliableHeadRequests.value_or(true)) {
+    if (config_->filesystem.reliable_head_requests.value_or(true)) {
         value.AddMember("reliableHeadRequests", true, allocator);
     }
 

--- a/lib/src/io/web_filesystem.cc
+++ b/lib/src/io/web_filesystem.cc
@@ -319,6 +319,10 @@ rapidjson::Value WebFileSystem::WebFile::WriteInfo(rapidjson::Document &doc) con
         filesystem_.config_->filesystem.allow_full_http_reads.value_or(true)) {
         value.AddMember("allowFullHttpReads", true, allocator);
     }
+    if ((data_protocol_ == DataProtocol::HTTP || data_protocol_ == DataProtocol::S3) &&
+        filesystem_.config_->filesystem.reliableHeadRequests.value_or(true)) {
+        value.AddMember("reliableHeadRequests", true, allocator);
+    }
     value.AddMember("collectStatistics", filesystem_.file_statistics_->TracksFile(file_name_), doc.GetAllocator());
 
     if (data_protocol_ == DataProtocol::S3) {
@@ -492,6 +496,9 @@ rapidjson::Value WebFileSystem::WriteGlobalFileInfo(rapidjson::Document &doc, ui
 
     if (config_->filesystem.allow_full_http_reads.value_or(true)) {
         value.AddMember("allowFullHttpReads", true, allocator);
+    }
+    if (config_->filesystem.reliableHeadRequests.value_or(true)) {
+        value.AddMember("reliableHeadRequests", true, allocator);
     }
 
     value.AddMember("s3Config", writeS3Config(config_->duckdb_config_options, allocator), allocator);

--- a/packages/duckdb-wasm-shell/crate/src/duckdb/web_file.rs
+++ b/packages/duckdb-wasm-shell/crate/src/duckdb/web_file.rs
@@ -23,7 +23,7 @@ pub struct WebFile {
     #[serde(rename = "dataNativeFd")]
     pub data_native_fd: Option<u64>,
     #[serde(rename = "reliableHeadRequests")]
-    pub allow_full_http_reads: Option<bool>,
+    pub reliable_head_requests: Option<bool>,
     #[serde(rename = "allowFullHttpReads")]
     pub allow_full_http_reads: Option<bool>,
     #[serde(rename = "collectStatistics")]

--- a/packages/duckdb-wasm-shell/crate/src/duckdb/web_file.rs
+++ b/packages/duckdb-wasm-shell/crate/src/duckdb/web_file.rs
@@ -22,6 +22,8 @@ pub struct WebFile {
     pub data_url: Option<String>,
     #[serde(rename = "dataNativeFd")]
     pub data_native_fd: Option<u64>,
+    #[serde(rename = "reliableHeadRequests")]
+    pub allow_full_http_reads: Option<bool>,
     #[serde(rename = "allowFullHttpReads")]
     pub allow_full_http_reads: Option<bool>,
     #[serde(rename = "collectStatistics")]

--- a/packages/duckdb-wasm/src/bindings/config.ts
+++ b/packages/duckdb-wasm/src/bindings/config.ts
@@ -25,6 +25,7 @@ export interface DuckDBFilesystemConfig {
     /**
      * Allow falling back to full HTTP reads if the server does not support range requests.
      */
+    reliableHeadRequests?: boolean;
     allowFullHTTPReads?: boolean;
 }
 

--- a/packages/duckdb-wasm/src/bindings/runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime.ts
@@ -76,6 +76,7 @@ export interface DuckDBFileInfo {
     fileName: string;
     dataProtocol: DuckDBDataProtocol;
     dataUrl: string | null;
+    reliableHeadRequests?: boolean;
     allowFullHttpReads?: boolean;
     s3Config?: S3Config;
 }
@@ -83,6 +84,7 @@ export interface DuckDBFileInfo {
 /** Global info for all files registered with DuckDB */
 export interface DuckDBGlobalFileInfo {
     cacheEpoch: number;
+    reliableHeadRequests?: boolean;
     allowFullHttpReads?: boolean;
     s3Config?: S3Config;
 }

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -159,7 +159,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                     // Supports ranges?
                     let contentLength = null;
                     let error: any | null = null;
-                    if (!file.allowFullHttpReads) {
+                    if (file.reliableHeadRequests || !file.allowFullHttpReads) {
                     try {
                         // Send a dummy HEAD request with range protocol
                         //          -> good IFF status is 206 and contentLenght is present
@@ -211,7 +211,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                             let presumedLength = null;
                             if (contentRange !== undefined) {
                                 presumedLength = contentRange;
-                            } else {
+                            } else if (!file.reliableHeadRequests) {
                                 // Send a dummy HEAD request with range protocol
                                 //          -> good IFF status is 206 and contentLenght is present
                                 const head = new XMLHttpRequest();

--- a/packages/duckdb-wasm/src/bindings/web_file.ts
+++ b/packages/duckdb-wasm/src/bindings/web_file.ts
@@ -8,5 +8,6 @@ export interface WebFile {
     dataUrl?: string;
     dataNativeFd?: number;
     collectStatistics?: boolean;
+    reliableHeadRequests?: boolean;
     allowFullHttpReads?: boolean;
 }


### PR DESCRIPTION
Aim at fixing https://github.com/duckdb/duckdb-wasm/issues/1658, or experimenting with the problem, by allowing to turn off `reliableHeadRequests` setting and consequently avoiding to perform HEAD requests that might mix up content length due to difference between of resource length before or after compression.

This by default will not change anything, but make it possible to test this more properly.