### PR TITLE
Handle longer queries

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -321,6 +321,7 @@ if(EMSCRIPTEN)
           _duckdb_web_prepared_send, \
           _duckdb_web_query_fetch_results, \
           _duckdb_web_query_run, \
+          _duckdb_web_query_run_buffer, \
           _duckdb_web_reset, \
           _duckdb_web_tokenize, \
           _duckdb_web_udf_scalar_create \

--- a/lib/src/webdb_api.cc
+++ b/lib/src/webdb_api.cc
@@ -187,6 +187,15 @@ void duckdb_web_query_run(WASMResponse* packed, ConnectionHdl connHdl, const cha
     auto r = c->RunQuery(script);
     WASMResponseBuffer::Get().Store(*packed, std::move(r));
 }
+
+/// Run a query (as a buffer)
+void duckdb_web_query_run_buffer(WASMResponse* packed, ConnectionHdl connHdl, const uint8_t* buffer,
+                                 size_t buffer_length) {
+    auto c = reinterpret_cast<WebDB::Connection*>(connHdl);
+    std::string_view S(reinterpret_cast<const char*>(buffer), buffer_length);
+    auto r = c->RunQuery(S);
+    WASMResponseBuffer::Get().Store(*packed, std::move(r));
+}
 /// Start a pending query
 void duckdb_web_pending_query_start(WASMResponse* packed, ConnectionHdl connHdl, const char* script) {
     auto c = reinterpret_cast<WebDB::Connection*>(connHdl);

--- a/packages/duckdb-wasm/test/index_browser.ts
+++ b/packages/duckdb-wasm/test/index_browser.ts
@@ -107,6 +107,7 @@ import { testTokenization, testTokenizationAsync } from './tokenizer.test';
 import { testTableNames, testTableNamesAsync } from './tablenames.test';
 import { testRegressionAsync } from './regression';
 import { testUDF } from './udf.test';
+import { longQueries } from './long_queries.test';
 //import { testEXCEL } from './excel.test';
 //import { testJSON } from './json.test';
 
@@ -116,6 +117,7 @@ const dataURL = `${baseURL}/data`;
 testHTTPFS(() => db!);
 testHTTPFSAsync(() => adb!, resolveData, dataURL);
 testUDF(() => db!);
+longQueries(() => adb!);
 testTableNames(() => db!);
 testTableNamesAsync(() => adb!);
 testRegressionAsync(() => adb!);

--- a/packages/duckdb-wasm/test/index_node.ts
+++ b/packages/duckdb-wasm/test/index_node.ts
@@ -76,10 +76,12 @@ import { testCSVInsert, testCSVInsertAsync } from './insert_csv.test';
 import { testTokenization, testTokenizationAsync } from './tokenizer.test';
 import { testTableNames, testTableNamesAsync } from './tablenames.test';
 import { testUDF } from './udf.test';
+import { longQueries } from './long_queries.test';
 import { testRegressionAsync } from './regression';
 import { testFTS } from './fts.test';
 
 testUDF(() => db!);
+longQueries(() => adb!);
 testTableNames(() => db!);
 testTableNamesAsync(() => adb!);
 testRegressionAsync(() => adb!);

--- a/packages/duckdb-wasm/test/long_queries.test.ts
+++ b/packages/duckdb-wasm/test/long_queries.test.ts
@@ -1,0 +1,39 @@
+import * as duckdb from '../src';
+
+// https://github.com/duckdb/duckdb-wasm/issues/393
+export function longQueries(db: () => duckdb.AsyncDuckDB): void {
+    let conn: duckdb.AsyncDuckDBConnection | null = null;
+    beforeEach(async () => {
+        await db().flushFiles();
+    });
+    afterEach(async () => {
+        if (conn) {
+            await conn.close();
+            conn = null;
+        }
+        await db().flushFiles();
+        await db().dropFiles();
+    });
+    describe('Very long queries', () => {
+        it('1e6', async () => {
+            await db().open({
+                path: ':memory:',
+                query: {
+                    castTimestampToDate: false,
+                },
+            });
+            conn = await db().connect();
+
+            let str = `with big_expr as ( select `;
+            let i = 1;
+                while (str.length < 1e6) {
+                str += ` ` + i + ` as col_` + i + `,`;
+                i++;
+            }
+            str += ` NULL as col_NULL) select 99;`
+
+            await conn.query(str);
+        });
+    });
+}
+


### PR DESCRIPTION
duckdb_web_query_run implicitly relied on stack-allocated strings for handling `ccall` Emscripten mechanisms.

Move to explicit allocations in the HEAPU8 buffer and passing around only pointers.

Before this fix queries at around 64K would become buggy, now up to 1e7, possibly even more can be handled.

This fixes a long standing issue in https://github.com/duckdb/duckdb-wasm/issues/1477