### PR TITLE
Add patches from SMALLER_BINARY PR

### DIFF
--- a/patches/duckdb/binary_executor.patch
+++ b/patches/duckdb/binary_executor.patch
@@ -1,0 +1,92 @@
+diff --git a/src/include/duckdb/common/vector_operations/binary_executor.hpp b/src/include/duckdb/common/vector_operations/binary_executor.hpp
+index 55c10bb289..c5f57edabf 100644
+--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
++++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
+@@ -381,6 +381,8 @@ public:
+ 		}
+ 	}
+ 
++#define DUCKDB_SMALLER_BINARY
++
+ 	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
+ 	static idx_t SelectFlat(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+ 	                        SelectionVector *true_sel, SelectionVector *false_sel) {
+@@ -417,14 +419,22 @@ public:
+ 			    ldata, rdata, sel, count, combined_mask, true_sel, false_sel);
+ 		}
+ 	}
+-
++#ifndef DUCKDB_SMALLER_BINARY
+ 	template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool NO_NULL, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
++#else
++	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
++#endif
+ 	static inline idx_t
+ 	SelectGenericLoop(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
+ 	                  const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+ 	                  const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lvalidity,
+ 	                  ValidityMask &rvalidity, SelectionVector *true_sel, SelectionVector *false_sel) {
+ 		idx_t true_count = 0, false_count = 0;
++#ifdef DUCKDB_SMALLER_BINARY
++		const bool HAS_TRUE_SEL = true_sel;
++		const bool HAS_FALSE_SEL = false_sel;
++		const bool NO_NULL = false;
++#endif
+ 		for (idx_t i = 0; i < count; i++) {
+ 			auto result_idx = result_sel->get_index(i);
+ 			auto lindex = lsel->get_index(i);
+@@ -452,6 +462,7 @@ public:
+ 	                           const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+ 	                           const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lvalidity,
+ 	                           ValidityMask &rvalidity, SelectionVector *true_sel, SelectionVector *false_sel) {
++#ifndef DUCKDB_SMALLER_BINARY
+ 		if (true_sel && false_sel) {
+ 			return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, true, true>(
+ 			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
+@@ -463,6 +474,10 @@ public:
+ 			return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, false, true>(
+ 			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
+ 		}
++#else
++		return SelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP>(ldata, rdata, lsel, rsel, result_sel, count, lvalidity,
++		                                                    rvalidity, true_sel, false_sel);
++#endif
+ 	}
+ 
+ 	template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+@@ -471,10 +486,13 @@ public:
+ 	                        const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+ 	                        const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lvalidity,
+ 	                        ValidityMask &rvalidity, SelectionVector *true_sel, SelectionVector *false_sel) {
++#ifndef DUCKDB_SMALLER_BINARY
+ 		if (!lvalidity.AllValid() || !rvalidity.AllValid()) {
+ 			return SelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, false>(
+ 			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
+-		} else {
++		} else
++#endif
++		{
+ 			return SelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, true>(
+ 			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
+ 		}
+@@ -502,6 +520,7 @@ public:
+ 		if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
+ 		    right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+ 			return SelectConstant<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, sel, count, true_sel, false_sel);
++#ifndef DUCKDB_SMALLER_BINARY
+ 		} else if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
+ 		           right.GetVectorType() == VectorType::FLAT_VECTOR) {
+ 			return SelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, true, false>(left, right, sel, count, true_sel, false_sel);
+@@ -511,10 +530,12 @@ public:
+ 		} else if (left.GetVectorType() == VectorType::FLAT_VECTOR &&
+ 		           right.GetVectorType() == VectorType::FLAT_VECTOR) {
+ 			return SelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, false>(left, right, sel, count, true_sel, false_sel);
++#endif
+ 		} else {
+ 			return SelectGeneric<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, sel, count, true_sel, false_sel);
+ 		}
+ 	}
++#undef DUCKDB_SMALLER_BINARY
+ };
+ 
+ } // namespace duckdb

--- a/patches/duckdb/is_distict_from.patch
+++ b/patches/duckdb/is_distict_from.patch
@@ -1,0 +1,86 @@
+diff --git a/src/common/vector_operations/is_distinct_from.cpp b/src/common/vector_operations/is_distinct_from.cpp
+index e9a31ee0e6..7694001647 100644
+--- a/src/common/vector_operations/is_distinct_from.cpp
++++ b/src/common/vector_operations/is_distinct_from.cpp
+@@ -65,17 +65,28 @@ static void DistinctExecute(Vector &left, Vector &right, Vector &result, idx_t c
+ 	DistinctExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result, count);
+ }
+ 
++#define DUCKDB_SMALLER_BINARY
++
++#ifndef DUCKDB_SMALLER_BINARY
+ template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool NO_NULL, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
++#else
++template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
++#endif
+ static inline idx_t
+ DistinctSelectGenericLoop(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *__restrict rdata,
+                           const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+                           const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
+                           ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
++#ifdef DUCKDB_SMALLER_BINARY
++	bool HAS_TRUE_SEL = true_sel;
++	bool HAS_FALSE_SEL = false_sel;
++#endif
+ 	idx_t true_count = 0, false_count = 0;
+ 	for (idx_t i = 0; i < count; i++) {
+ 		auto result_idx = result_sel->get_index(i);
+ 		auto lindex = lsel->get_index(i);
+ 		auto rindex = rsel->get_index(i);
++#ifndef DUCKDB_SMALLER_BINARY
+ 		if (NO_NULL) {
+ 			if (OP::Operation(ldata[lindex], rdata[rindex], false, false)) {
+ 				if (HAS_TRUE_SEL) {
+@@ -86,7 +97,9 @@ DistinctSelectGenericLoop(const LEFT_TYPE *__restrict ldata, const RIGHT_TYPE *_
+ 					false_sel->set_index(false_count++, result_idx);
+ 				}
+ 			}
+-		} else {
++		} else
++#endif
++		{
+ 			if (OP::Operation(ldata[lindex], rdata[rindex], !lmask.RowIsValid(lindex), !rmask.RowIsValid(rindex))) {
+ 				if (HAS_TRUE_SEL) {
+ 					true_sel->set_index(true_count++, result_idx);
+@@ -129,6 +142,7 @@ DistinctSelectGenericLoopSwitch(const LEFT_TYPE *__restrict ldata, const RIGHT_T
+                                 const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+                                 const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
+                                 ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
++#ifndef DUCKDB_SMALLER_BINARY
+ 	if (!lmask.AllValid() || !rmask.AllValid()) {
+ 		return DistinctSelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, false>(
+ 		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+@@ -136,6 +150,10 @@ DistinctSelectGenericLoopSwitch(const LEFT_TYPE *__restrict ldata, const RIGHT_T
+ 		return DistinctSelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, true>(
+ 		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+ 	}
++#else
++	return DistinctSelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP>(ldata, rdata, lsel, rsel, result_sel, count, lmask,
++	                                                            rmask, true_sel, false_sel);
++#endif
+ }
+ 
+ template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+@@ -287,6 +305,7 @@ static idx_t DistinctSelect(Vector &left, Vector &right, const SelectionVector *
+ 
+ 	if (left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+ 		return DistinctSelectConstant<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, sel, count, true_sel, false_sel);
++#ifndef DUCKDB_SMALLER_BINARY
+ 	} else if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
+ 	           right.GetVectorType() == VectorType::FLAT_VECTOR) {
+ 		return DistinctSelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, true, false>(left, right, sel, count, true_sel, false_sel);
+@@ -296,11 +315,14 @@ static idx_t DistinctSelect(Vector &left, Vector &right, const SelectionVector *
+ 	} else if (left.GetVectorType() == VectorType::FLAT_VECTOR && right.GetVectorType() == VectorType::FLAT_VECTOR) {
+ 		return DistinctSelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, false>(left, right, sel, count, true_sel,
+ 		                                                                   false_sel);
++#endif
+ 	} else {
+ 		return DistinctSelectGeneric<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, sel, count, true_sel, false_sel);
+ 	}
+ }
+ 
++#undef DUCKDB_SMALLER_BINARY
++
+ template <class OP>
+ static idx_t DistinctSelectNotNull(Vector &left, Vector &right, const idx_t count, idx_t &true_count,
+                                    const SelectionVector &sel, SelectionVector &maybe_vec, OptionalSelection &true_opt,

--- a/patches/duckdb/smaller_casts.patch
+++ b/patches/duckdb/smaller_casts.patch
@@ -1,0 +1,151 @@
+diff --git a/.github/workflows/Regression.yml b/.github/workflows/Regression.yml
+index 25b5a470f7..bc9e633d0a 100644
+--- a/.github/workflows/Regression.yml
++++ b/.github/workflows/Regression.yml
+@@ -77,6 +77,11 @@ jobs:
+         make
+         cd ..
+ 
++    - name: List sizes of both binaries
++      shell: bash
++      run: |
++        ls -la build/release/duckdb duckdb/build/release/duckdb
++
+     - name: Set up benchmarks
+       shell: bash
+       run: |
+diff --git a/src/function/cast/enum_casts.cpp b/src/function/cast/enum_casts.cpp
+index 7e22cb932d..2b5b604982 100644
+--- a/src/function/cast/enum_casts.cpp
++++ b/src/function/cast/enum_casts.cpp
+@@ -17,8 +17,9 @@ bool EnumEnumCast(Vector &source, Vector &result, idx_t count, CastParameters &p
+ 		    auto key = EnumType::GetPos(res_enum_type, dictionary_data[value]);
+ 		    if (key == -1) {
+ 			    if (!parameters.error_message) {
+-				    return HandleVectorCastError::Operation<RES_TYPE>(CastExceptionText<SRC_TYPE, RES_TYPE>(value),
+-				                                                      mask, row_idx, vector_cast_data);
++				    return HandleVectorCastError::Operation<RES_TYPE>(
++				        CastExceptionText<SRC_TYPE>(value, TypeIdInfo::CreateObject<RES_TYPE>), mask, row_idx,
++				        vector_cast_data);
+ 			    } else {
+ 				    mask.SetInvalid(row_idx);
+ 			    }
+diff --git a/src/function/cast/string_cast.cpp b/src/function/cast/string_cast.cpp
+index 9f8b5ee298..5fd0d370fe 100644
+--- a/src/function/cast/string_cast.cpp
++++ b/src/function/cast/string_cast.cpp
+@@ -22,8 +22,10 @@ bool StringEnumCastLoop(const string_t *source_data, ValidityMask &source_mask,
+ 		if (source_mask.RowIsValid(source_idx)) {
+ 			auto pos = EnumType::GetPos(result_type, source_data[source_idx]);
+ 			if (pos == -1) {
++
+ 				result_data[i] = HandleVectorCastError::Operation<T>(
+-				    CastExceptionText<string_t, T>(source_data[source_idx]), result_mask, i, vector_cast_data);
++				    CastExceptionText<string_t>(source_data[source_idx], TypeIdInfo::CreateObject<T>), result_mask, i,
++				    vector_cast_data);
+ 			} else {
+ 				result_data[i] = UnsafeNumericCast<T>(pos);
+ 			}
+diff --git a/src/include/duckdb/common/operator/cast_operators.hpp b/src/include/duckdb/common/operator/cast_operators.hpp
+index 3e4cb35e92..2b157157e2 100644
+--- a/src/include/duckdb/common/operator/cast_operators.hpp
++++ b/src/include/duckdb/common/operator/cast_operators.hpp
+@@ -51,19 +51,31 @@ struct TryCastErrorMessageCommaSeparated {
+ 	}
+ };
+ 
+-template <class SRC, class DST>
+-static string CastExceptionText(SRC input) {
++struct TypeIdInfo {
++	explicit TypeIdInfo(string name, bool isNum) : name(name), isNum(isNum) {
++	}
++	template <typename TYPE>
++	__attribute__((noinline)) static TypeIdInfo CreateObject() {
++		return TypeIdInfo(TypeIdToString(GetTypeId<TYPE>()), TypeIsNumber<TYPE>());
++	}
++	string name;
++	bool isNum;
++};
++
++typedef TypeIdInfo (*callback_typeidinfo)(void);
++
++template <class SRC>
++static string CastExceptionText(SRC input, callback_typeidinfo func) {
++	auto info = func();
+ 	if (std::is_same<SRC, string_t>()) {
+-		return "Could not convert string '" + ConvertToString::Operation<SRC>(input) + "' to " +
+-		       TypeIdToString(GetTypeId<DST>());
++		return "Could not convert string '" + ConvertToString::Operation<SRC>(input) + "' to " + info.name;
+ 	}
+-	if (TypeIsNumber<SRC>() && TypeIsNumber<DST>()) {
++	if (TypeIsNumber<SRC>() && info.isNum) {
+ 		return "Type " + TypeIdToString(GetTypeId<SRC>()) + " with value " + ConvertToString::Operation<SRC>(input) +
+-		       " can't be cast because the value is out of range for the destination type " +
+-		       TypeIdToString(GetTypeId<DST>());
++		       " can't be cast because the value is out of range for the destination type " + info.name;
+ 	}
+ 	return "Type " + TypeIdToString(GetTypeId<SRC>()) + " with value " + ConvertToString::Operation<SRC>(input) +
+-	       " can't be cast to the destination type " + TypeIdToString(GetTypeId<DST>());
++	       " can't be cast to the destination type " + info.name;
+ }
+ 
+ struct Cast {
+@@ -71,7 +83,7 @@ struct Cast {
+ 	static inline DST Operation(SRC input) {
+ 		DST result;
+ 		if (!TryCast::Operation(input, result)) {
+-			throw InvalidInputException(CastExceptionText<SRC, DST>(input));
++			throw InvalidInputException(CastExceptionText<SRC>(input, TypeIdInfo::CreateObject<DST>));
+ 		}
+ 		return result;
+ 	}
+diff --git a/src/include/duckdb/function/cast/vector_cast_helpers.hpp b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+index 9766df4e32..8e07c465b4 100644
+--- a/src/include/duckdb/function/cast/vector_cast_helpers.hpp
++++ b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+@@ -35,8 +35,8 @@ struct VectorTryCastOperator {
+ 			return output;
+ 		}
+ 		auto data = reinterpret_cast<VectorTryCastData *>(dataptr);
+-		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+-		                                                     idx, *data);
++		return HandleVectorCastError::Operation<RESULT_TYPE>(
++		    CastExceptionText<INPUT_TYPE>(input, TypeIdInfo::CreateObject<RESULT_TYPE>), mask, idx, *data);
+ 	}
+ };
+ 
+@@ -49,8 +49,9 @@ struct VectorTryCastStrictOperator {
+ 		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->parameters.strict))) {
+ 			return output;
+ 		}
+-		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+-		                                                     idx, *data);
++
++		return HandleVectorCastError::Operation<RESULT_TYPE>(
++		    CastExceptionText<INPUT_TYPE>(input, TypeIdInfo::CreateObject<RESULT_TYPE>), mask, idx, *data);
+ 	}
+ };
+ 
+@@ -65,8 +66,9 @@ struct VectorTryCastErrorOperator {
+ 		}
+ 		bool has_error = data->parameters.error_message && !data->parameters.error_message->empty();
+ 		return HandleVectorCastError::Operation<RESULT_TYPE>(
+-		    has_error ? *data->parameters.error_message : CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask, idx,
+-		    *data);
++		    has_error ? *data->parameters.error_message
++		              : CastExceptionText<INPUT_TYPE>(input, TypeIdInfo::CreateObject<RESULT_TYPE>),
++		    mask, idx, *data);
+ 	}
+ };
+ 
+@@ -80,8 +82,8 @@ struct VectorTryCastStringOperator {
+ 		        OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->result, data->parameters))) {
+ 			return output;
+ 		}
+-		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+-		                                                     idx, *data);
++		return HandleVectorCastError::Operation<RESULT_TYPE>(
++		    CastExceptionText<INPUT_TYPE>(input, TypeIdInfo::CreateObject<RESULT_TYPE>), mask, idx, *data);
+ 	}
+ };
+ 

--- a/patches/duckdb/unary_executor.patch
+++ b/patches/duckdb/unary_executor.patch
@@ -1,0 +1,37 @@
+diff --git a/src/include/duckdb/common/vector_operations/unary_executor.hpp b/src/include/duckdb/common/vector_operations/unary_executor.hpp
+index 9f29d7410f..bf77c61e7a 100644
+--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
++++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
+@@ -136,6 +136,8 @@ private:
+ 		}
+ 	}
+ 
++#define DUCKDB_SMALLER_BINARY
++
+ 	template <class INPUT_TYPE, class RESULT_TYPE, class OPWRAPPER, class OP>
+ 	static inline void ExecuteStandard(Vector &input, Vector &result, idx_t count, void *dataptr, bool adds_nulls) {
+ 		switch (input.GetVectorType()) {
+@@ -153,6 +155,7 @@ private:
+ 			}
+ 			break;
+ 		}
++#ifndef DUCKDB_SMALLER_BINARY
+ 		case VectorType::FLAT_VECTOR: {
+ 			result.SetVectorType(VectorType::FLAT_VECTOR);
+ 			auto result_data = FlatVector::GetData<RESULT_TYPE>(result);
+@@ -162,6 +165,7 @@ private:
+ 			                                                    FlatVector::Validity(result), dataptr, adds_nulls);
+ 			break;
+ 		}
++#endif
+ 		default: {
+ 			UnifiedVectorFormat vdata;
+ 			input.ToUnifiedFormat(count, vdata);
+@@ -176,6 +180,7 @@ private:
+ 		}
+ 		}
+ 	}
++#undef DUCKDB_SMALLER_BINARY
+ 
+ public:
+ 	template <class INPUT_TYPE, class RESULT_TYPE, class OP>


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/14057 introduced (in DuckDB feature) the concept of opt-out certain code-path that are not strictly needed for correctness, and only impact speed of execution.

Cherry-picking some of that into `v1.1.1`, to decrease uncompressed DuckDB Wasm sizes like:
| file  | current main | PR |
| --- | ---- | ----- |
| dist/duckdb-coi.wasm                                          |          38.4 MB |   35.5 MB | 
| dist/duckdb-eh.wasm                                            |         38.5 MB | 35.7 MB |
| dist/duckdb-mvp.wasm                                          |          43.6 MB |  40.6 MB |