### PR TITLE
Compile COI bundle with Emscripten 3.1.67

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ concurrency:
 
 env:
   EMSCRIPTEN_VERSION: 'latest'
+  EMSCRIPTEN_VERSION_COI: '3.1.67'
 
 jobs:
     clang_format:
@@ -456,7 +457,7 @@ jobs:
 
             - uses: mymindstorm/setup-emsdk@v14
               with:
-                  version: ${{ env.EMSCRIPTEN_VERSION }}
+                  version: ${{ env.EMSCRIPTEN_VERSION_COI }}
 
             - name: Setup Ccache
               uses: hendrikmuhs/ccache-action@main
@@ -586,7 +587,7 @@ jobs:
 
             - uses: mymindstorm/setup-emsdk@v14
               with:
-                  version: ${{ env.EMSCRIPTEN_VERSION }}
+                  version: ${{ env.EMSCRIPTEN_VERSION_COI }}
 
             - name: Setup Ccache
               uses: hendrikmuhs/ccache-action@main

--- a/packages/duckdb-wasm-app/src/app.tsx
+++ b/packages/duckdb-wasm-app/src/app.tsx
@@ -30,7 +30,7 @@ const DUCKDB_BUNDLES: duckdb.DuckDBBundles = {
         mainModule: duckdb_wasm_coi,
         mainWorker: new URL('@duckdb/duckdb-wasm/dist/duckdb-browser-coi.worker.js', import.meta.url).toString(),
         pthreadWorker: new URL(
-            '@duckdb/duckdb-wasm/dist/duckdb-browser-coi.worker.js',
+            '@duckdb/duckdb-wasm/dist/duckdb-browser-coi.pthread.worker.js',
             import.meta.url,
         ).toString(),
     },

--- a/packages/duckdb-wasm/bundle.mjs
+++ b/packages/duckdb-wasm/bundle.mjs
@@ -104,7 +104,7 @@ fs.copyFile(path.resolve(src, 'bindings', 'duckdb-coi.wasm'), path.resolve(dist,
     patchFile('./src/bindings/duckdb-mvp.js', 'child_process');
     patchFile('./src/bindings/duckdb-eh.js', 'child_process');
     patchFile('./src/bindings/duckdb-coi.js', 'child_process');
-   // patchFile('./src/bindings/duckdb-coi.pthread.js', 'vm');
+    patchFile('./src/bindings/duckdb-coi.pthread.js', 'vm');
 
     // -------------------------------
     // Browser bundles
@@ -216,7 +216,7 @@ fs.copyFile(path.resolve(src, 'bindings', 'duckdb-coi.wasm'), path.resolve(dist,
         external: EXTERNALS_WEBWORKER,
         define: { 'process.release.name': '"browser"' },
     });
-/*
+
     console.log('[ ESBUILD ] duckdb-browser-coi.pthread.worker.js');
     await esbuild.build({
         entryPoints: ['./src/targets/duckdb-browser-coi.pthread.worker.ts'],
@@ -230,7 +230,7 @@ fs.copyFile(path.resolve(src, 'bindings', 'duckdb-coi.wasm'), path.resolve(dist,
         external: EXTERNALS_WEBWORKER,
         define: { 'process.release.name': '"browser"' },
     });
-*/
+
     // -------------------------------
     // Node bundles
 

--- a/packages/duckdb-wasm/test/index_browser.ts
+++ b/packages/duckdb-wasm/test/index_browser.ts
@@ -15,7 +15,7 @@ const DUCKDB_BUNDLES: duckdb.DuckDBBundles = {
     coi: {
         mainModule: new URL('/static/duckdb-coi.wasm', window.location.href).href,
         mainWorker: new URL('/static/duckdb-browser-coi.worker.js', window.location.href).href,
-        pthreadWorker: new URL('/static/duckdb-browser-coi.worker.js', window.location.href).href,
+        pthreadWorker: new URL('/static/duckdb-browser-coi.pthread.worker.js', window.location.href).href,
     },
 };
 let DUCKDB_BUNDLE: duckdb.DuckDBBundle | null = null;


### PR DESCRIPTION
https://github.com/emscripten-core/emscripten/pull/22598 changed to remove the worker specific logic, but we still need to adapt to it.
Once that's done, this can be reverted.