### PR TITLE
Fix to build failure for duckdb_wasm sub-project test

### DIFF
--- a/lib/cmake/duckdb.cmake
+++ b/lib/cmake/duckdb.cmake
@@ -87,6 +87,7 @@ target_link_libraries(
   INTERFACE ${install_dir}/lib/libduckdb_miniz.a
   INTERFACE ${install_dir}/lib/libduckdb_mbedtls.a
   INTERFACE ${install_dir}/lib/libduckdb_yyjson.a
+  INTERFACE ${install_dir}/lib/libduckdb_skiplistlib.a
   INTERFACE ${install_dir}/lib/libduckdb_pg_query.a
   INTERFACE ${install_dir}/lib/libduckdb_utf8proc.a
   INTERFACE ${install_dir}/lib/libduckdb_fastpforlib.a


### PR DESCRIPTION
### Description

This is PR for issue #1888.
A test for `duckdb_wasm` sub-project has failed to build.
It resolves this issue.

### Out-of-scope

To build test artifact is success, but executing test still fails.
Following testcases:

#### AllTypesTest.FullRangeTypes

This test is used a udf `test_all_types`.
It fails to not match expects columns with `test_all_types` columns.
It will be easy modifying.

### ParquetLoadTest.LoadParquet

In 1.29.0, DuckDB extensions support enabled by default.
So calling `duckdb_web_parquet_init(&db->database())` failes.
It will be easy modifying. (line-delete only)

Same for the following

* ParquetLoadTest.LoadParquetTwice
* FileSystemBufferTest.FlushFrameMemoryBugRegression
* WebFileSystemTest.LoadParquet

### CSVExportTest.TestExport

This test fails calling `WebDB::Connection::InsertCSVFromPath`.

```
{"exception_type":"Not implemented","exception_message":"Unsupported compression type for default file system"}
```

But this method does not have a compression option.
It makes no sense for me.

### FilePageBufferTest.FixSingle

It fails calling `TestableFilePageBuffer::BuffersFile` after `FilePageBuffer::FileRef::Release`.
It seems that accessing released file buffer is incorrect.
It will need to make this specification clear.

