### PR TITLE
Add duckdb patch signature_capi

### DIFF
--- a/patches/duckdb/signature_capi.patch
+++ b/patches/duckdb/signature_capi.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/extension/extension_load.cpp b/src/main/extension/extension_load.cpp
+index 59fc4e8cd9..b0282a7103 100644
+--- a/src/main/extension/extension_load.cpp
++++ b/src/main/extension/extension_load.cpp
+@@ -119,7 +119,7 @@ struct ExtensionAccess {
+ // The C++ init function
+ typedef void (*ext_init_fun_t)(DatabaseInstance &);
+ // The C init function
+-typedef void (*ext_init_c_api_fun_t)(duckdb_extension_info info, duckdb_extension_access *access);
++typedef bool (*ext_init_c_api_fun_t)(duckdb_extension_info info, duckdb_extension_access *access);
+ typedef const char *(*ext_version_fun_t)(void);
+ typedef bool (*ext_is_storage_t)(void);
+ 


### PR DESCRIPTION
Signature of capi extensions changed from returning void to returning a boolean, mismatch on native targets is fine, since result is just ignored, but flagged problems in wasm validation due to signature changing in an incompatible way from `(int,int)->()` to `(int,int)->(int)`.

Given the error is on validation of indirect call, I am not aware of a workaround Wasm side, and given capi extensions are still experimental, and more so in duckdb-wasm, I would propose taking this liberty from DuckDB source code to allow more simpler exploration on this matter.

Discussed with @samansmink.