### PR TITLE
Lock emscripten on version 3.1.71

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  EMSCRIPTEN_VERSION: 'latest'
+  EMSCRIPTEN_VERSION: '3.1.71'
   EMSCRIPTEN_VERSION_COI: '3.1.57'
 
 jobs:


### PR DESCRIPTION
This is due to changes in dynamic linking ABI connected virtual table calls. Tracking issue is at https://github.com/duckdb/duckdb-wasm/issues/1923