### PR TITLE
Fix return type of `AsyncDuckDBConnection.prepare`

### DIFF
--- a/packages/duckdb-wasm/src/parallel/async_connection.ts
+++ b/packages/duckdb-wasm/src/parallel/async_connection.ts
@@ -84,7 +84,7 @@ export class AsyncDuckDBConnection {
     /** Create a prepared statement */
     public async prepare<T extends { [key: string]: arrow.DataType } = any>(
         text: string,
-    ): Promise<AsyncPreparedStatement> {
+    ): Promise<AsyncPreparedStatement<T>> {
         const stmt = await this._bindings.createPrepared(this._conn, text);
         return new AsyncPreparedStatement<T>(this._bindings, this._conn, stmt);
     }


### PR DESCRIPTION
This looks like it is supposed to return `AsyncPreparedStatement<T>` but since the type parameter is not provided it actually returns `AsyncPreparedStatement<any>`. That passes type checking anyway since `any` is compatible with `T` but is inconvenient downstream since it doesn't actually use the type parameter.