### PR TITLE
Move back to syncronous function registerFileHandle in DuckDBBindings

### DIFF
--- a/packages/duckdb-wasm/src/bindings/bindings_interface.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_interface.ts
@@ -41,7 +41,19 @@ export interface DuckDBBindings {
         handle: HandleType,
         protocol: DuckDBDataProtocol,
         directIO: boolean,
+    ): void;
+    registerFileHandleAsync<HandleType>(
+        name: string,
+        handle: HandleType,
+        protocol: DuckDBDataProtocol,
+        directIO: boolean,
     ): Promise<void>;
+    prepareFileHandleAsync<HandleType>(
+        name: string,
+        handle: HandleType,
+        protocol: DuckDBDataProtocol,
+        directIO: boolean,
+    ): Promise<HandleType>;
     prepareDBFileHandle(path: string, protocol: DuckDBDataProtocol): Promise<void>;
     globFiles(path: string): WebFile[];
     dropFile(name: string): void;

--- a/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
@@ -328,7 +328,7 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
                     break;
 
                 case WorkerRequestType.REGISTER_FILE_HANDLE:
-                    await this._bindings.registerFileHandle(
+                    await this._bindings.registerFileHandleAsync(
                         request.data[0],
                         request.data[1],
                         request.data[2],


### PR DESCRIPTION
Iterating on https://github.com/duckdb/duckdb-wasm/pull/1856, this keeps the same API as before, in case somehow were to rely on that.

Pining, @e1arikawa, if you have any concern / what to review this.