### PR TITLE
Handle graciously failures on Close

### DIFF
--- a/lib/include/duckdb/web/io/web_filesystem.h
+++ b/lib/include/duckdb/web/io/web_filesystem.h
@@ -141,7 +141,13 @@ class WebFileSystem : public duckdb::FileSystem {
         /// Delete copy constructor
         WebFileHandle(const WebFileHandle &) = delete;
         /// Destructor
-        virtual ~WebFileHandle() { Close(); }
+        virtual ~WebFileHandle() {
+            try {
+                Close();
+            } catch (...) {
+                // Avoid crashes if Close happens to throw
+            }
+        }
         /// Get the file name
         auto &GetName() const { return file_->file_name_; }
         /// Resolve readahead

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -475,6 +475,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
     closeFile: (mod: DuckDBModule, fileId: number) => {
         const file = BROWSER_RUNTIME.getFileInfo(mod, fileId);
         BROWSER_RUNTIME._fileInfoCache.delete(fileId);
+	try {
         switch (file?.dataProtocol) {
             case DuckDBDataProtocol.BUFFER:
             case DuckDBDataProtocol.HTTP:
@@ -491,6 +492,10 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                 }
                 return handle.flush();
             }
+        }
+        } catch (e: any) {
+            console.log(e);
+            failWith(mod, e.toString());
         }
     },
     dropFile: (mod: DuckDBModule, fileNamePtr: number, fileNameLen: number) => {

--- a/packages/duckdb-wasm/test/opfs.test.ts
+++ b/packages/duckdb-wasm/test/opfs.test.ts
@@ -201,6 +201,7 @@ export function testOPFS(baseDir: string, bundle: () => duckdb.DuckDBBundle): vo
             await db.registerFileHandle('test.csv', testHandle, duckdb.DuckDBDataProtocol.BROWSER_FSACCESS, true);
             await conn.send(`CREATE TABLE zzz AS SELECT * FROM "${baseDir}/tpch/0_01/parquet/lineitem.parquet"`);
             await conn.send(`COPY (SELECT * FROM zzz) TO 'test.csv'`);
+            await conn.send(`COPY (SELECT * FROM zzz) TO 'non_existing.csv'`);
             await conn.close();
             await db.dropFile('test.csv');
             await db.reset();


### PR DESCRIPTION
Needs first to avoid throwing in destructor (big no), AND to convert JS exception in C++ exception

More iteration on comments to https://github.com/duckdb/duckdb-wasm/pull/1856