### PR TITLE
registerOPFSFileName and relevant `.files register` in the shell

### DIFF
--- a/packages/duckdb-wasm-shell/crate/src/duckdb/async_duckdb.rs
+++ b/packages/duckdb-wasm-shell/crate/src/duckdb/async_duckdb.rs
@@ -63,6 +63,11 @@ extern "C" {
         conn: ConnectionID,
     ) -> Result<JsValue, JsValue>;
 
+    #[wasm_bindgen(catch, method, js_name = "registerOPFSFileName")]
+    async fn register_opfs_file_name(
+        this: &JsAsyncDuckDB,
+        text: &str,
+    ) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(catch, method, js_name = "collectFileStatistics")]
     async fn collect_file_statistics(
         this: &JsAsyncDuckDB,
@@ -155,6 +160,14 @@ impl AsyncDuckDB {
         enable: bool,
     ) -> Result<(), js_sys::Error> {
         self.bindings.collect_file_statistics(file, enable).await?;
+        Ok(())
+    }
+
+    pub async fn register_opfs_file_name(
+        &self,
+        file: &str,
+    ) -> Result<(), js_sys::Error> {
+        self.bindings.register_opfs_file_name(file).await?;
         Ok(())
     }
 

--- a/packages/duckdb-wasm-shell/crate/src/shell_api.rs
+++ b/packages/duckdb-wasm-shell/crate/src/shell_api.rs
@@ -65,6 +65,11 @@ pub fn writeln(text: &str) {
     Shell::with(|s| s.writeln(text));
 }
 
+#[wasm_bindgen(js_name = "registerOPFSFileName")]
+pub fn register_opfs_file_name(name: &str) {
+    Shell::register_opfs_file_name(name);
+}
+
 #[wasm_bindgen(js_name = "collectFileStatistics")]
 pub fn collect_file_statistics(name: &str, enable: bool) {
     Shell::collect_file_statistics(name, enable);

--- a/packages/duckdb-wasm/src/bindings/bindings_interface.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_interface.ts
@@ -62,6 +62,7 @@ export interface DuckDBBindings {
     flushFiles(): void;
     copyFileToPath(name: string, path: string): void;
     copyFileToBuffer(name: string): Uint8Array;
+    registerOPFSFileName(file: string): void;
     collectFileStatistics(file: string, enable: boolean): void;
     exportFileStatistics(file: string): FileStatistics;
 }

--- a/packages/duckdb-wasm/src/bindings/bindings_interface.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_interface.ts
@@ -54,6 +54,7 @@ export interface DuckDBBindings {
         protocol: DuckDBDataProtocol,
         directIO: boolean,
     ): Promise<HandleType>;
+    prepareFileHandle(path: string, protocol: DuckDBDataProtocol): Promise<void>;
     prepareDBFileHandle(path: string, protocol: DuckDBDataProtocol): Promise<void>;
     globFiles(path: string): WebFile[];
     dropFile(name: string): void;

--- a/packages/duckdb-wasm/src/bindings/runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime.ts
@@ -157,6 +157,8 @@ export interface DuckDBRuntime {
     removeFile(mod: DuckDBModule, pathPtr: number, pathLen: number): void;
 
     // Prepare a file handle that could only be acquired aschronously
+    prepareFileHandle?: (path: string, protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
+    prepareFileHandles?: (path: string[], protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
     prepareDBFileHandle?: (path: string, protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
 
     // Call a scalar UDF function

--- a/packages/duckdb-wasm/src/parallel/async_bindings.ts
+++ b/packages/duckdb-wasm/src/parallel/async_bindings.ts
@@ -160,6 +160,7 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
         switch (task.type) {
             case WorkerRequestType.CLOSE_PREPARED:
             case WorkerRequestType.COLLECT_FILE_STATISTICS:
+            case WorkerRequestType.REGISTER_OPFS_FILE_NAME:
             case WorkerRequestType.COPY_FILE_TO_PATH:
             case WorkerRequestType.DISCONNECT:
             case WorkerRequestType.DROP_FILE:
@@ -543,6 +544,15 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
             [string, any, DuckDBDataProtocol, boolean],
             null
         >(WorkerRequestType.REGISTER_FILE_HANDLE, [name, handle, protocol, directIO]);
+        await this.postTask(task, []);
+    }
+
+    /** Enable file statistics */
+    public async registerOPFSFileName(name: string): Promise<void> {
+        const task = new WorkerTask<WorkerRequestType.REGISTER_OPFS_FILE_NAME, [string], null>(
+            WorkerRequestType.REGISTER_OPFS_FILE_NAME,
+            [name],
+        );
         await this.postTask(task, []);
     }
 

--- a/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
@@ -360,6 +360,11 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
                     this.sendOK(request);
                     break;
 
+                case WorkerRequestType.REGISTER_OPFS_FILE_NAME:
+                    this._bindings.registerOPFSFileName(request.data[0]);
+                    this.sendOK(request);
+                    break;
+
                 case WorkerRequestType.EXPORT_FILE_STATISTICS: {
                     this.postMessage(
                         {

--- a/packages/duckdb-wasm/src/parallel/worker_request.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_request.ts
@@ -14,6 +14,7 @@ export enum WorkerRequestType {
     CANCEL_PENDING_QUERY = 'CANCEL_PENDING_QUERY',
     CLOSE_PREPARED = 'CLOSE_PREPARED',
     COLLECT_FILE_STATISTICS = 'COLLECT_FILE_STATISTICS',
+    REGISTER_OPFS_FILE_NAME = 'REGISTER_OPFS_FILE_NAME',
     CONNECT = 'CONNECT',
     COPY_FILE_TO_BUFFER = 'COPY_FILE_TO_BUFFER',
     COPY_FILE_TO_PATH = 'COPY_FILE_TO_PATH',
@@ -108,6 +109,7 @@ export type WorkerRequestVariant =
     | WorkerRequest<WorkerRequestType.CLOSE_PREPARED, [ConnectionID, StatementID]>
     | WorkerRequest<WorkerRequestType.CANCEL_PENDING_QUERY, number>
     | WorkerRequest<WorkerRequestType.COLLECT_FILE_STATISTICS, [string, boolean]>
+    | WorkerRequest<WorkerRequestType.REGISTER_OPFS_FILE_NAME, [string]>
     | WorkerRequest<WorkerRequestType.CONNECT, null>
     | WorkerRequest<WorkerRequestType.COPY_FILE_TO_BUFFER, string>
     | WorkerRequest<WorkerRequestType.COPY_FILE_TO_PATH, [string, string]>
@@ -166,6 +168,7 @@ export type WorkerResponseVariant =
 
 export type WorkerTaskVariant =
     | WorkerTask<WorkerRequestType.COLLECT_FILE_STATISTICS, [string, boolean], null>
+    | WorkerTask<WorkerRequestType.REGISTER_OPFS_FILE_NAME, [string], null>
     | WorkerTask<WorkerRequestType.CLOSE_PREPARED, [number, number], null>
     | WorkerTask<WorkerRequestType.CONNECT, null, ConnectionID>
     | WorkerTask<WorkerRequestType.COPY_FILE_TO_BUFFER, string, Uint8Array>


### PR DESCRIPTION
Allows, in the shell, to do:
```
.files register opfs://a.csv
COPY (SELECT 32) TO 'opfs://a.csv';
```
close tab, restart, then:
```
.files register opfs://a.csv
FROM 'opfs://a.csv';
```

Roadmap:
- [ ] Make registration of existing files automatic
- [ ] Allow clean-up of file
- [ ] Allow listing of files (and list them on startup)
- [ ] Allow reset of OPFS storage
- [ ] Make error situation clear in multi-tab scenario