### PR TITLE
Query progress updates to be passed to main thread

### DIFF
--- a/lib/include/duckdb/web/webdb.h
+++ b/lib/include/duckdb/web/webdb.h
@@ -33,6 +33,8 @@ class WebDB {
    public:
     /// A connection
     class Connection {
+        friend WebDB;
+
        protected:
         /// The webdb
         WebDB& webdb_;

--- a/lib/src/webdb.cc
+++ b/lib/src/webdb.cc
@@ -783,11 +783,29 @@ std::string WebDB::Tokenize(std::string_view text) {
 /// Get the version
 std::string_view WebDB::GetVersion() { return database_->LibraryVersion(); }
 
+class ProgressBarCustom: public ProgressBarDisplay {
+public:
+        ProgressBarCustom() {
+        }
+        ~ProgressBarCustom() {}
+public:
+        void Update(double percentage)  {
+		std::cout << "ProgressBar::Update() called with " << percentage << "\n";
+	}
+        void Finish() {
+		std::cout << "Finish() called\n";
+	}
+	static unique_ptr<ProgressBarDisplay> GetProgressBar() {
+		return make_uniq<ProgressBarCustom>();
+	}
+};
+
 /// Create a session
 WebDB::Connection* WebDB::Connect() {
     auto conn = duckdb::make_uniq<WebDB::Connection>(*this);
     auto conn_ptr = conn.get();
     connections_.insert({conn_ptr, std::move(conn)});
+    ClientConfig::GetConfig(*conn_ptr->connection_.context).display_create_func = ProgressBarCustom::GetProgressBar;
     return conn_ptr;
 }
 

--- a/lib/src/webdb.cc
+++ b/lib/src/webdb.cc
@@ -797,8 +797,8 @@ class ProgressBarCustom : public ProgressBarDisplay {
         to_send = 1.0;
     }
     ~ProgressBarCustom() {}
-    static void SendMessage(bool end, double percentage, double times) {
-        emscripten::val::global("DUCKDB_RUNTIME").call<void>("progressUpdate", end, percentage, times);
+    static void SendMessage(double end, double percentage, double times) {
+        emscripten::val::global("DUCKDB_RUNTIME").call<void>("progressUpdate", end ? 1.0 : 0.0, percentage, times);
     }
 
    public:

--- a/packages/duckdb-wasm/src/bindings/runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime.ts
@@ -142,6 +142,7 @@ export interface DuckDBRuntime {
     closeFile(mod: DuckDBModule, fileId: number): void;
     dropFile(mod: DuckDBModule, fileNamePtr: number, fileNameLen:number): void;
     getLastFileModificationTime(mod: DuckDBModule, fileId: number): number;
+    progressUpdate(mod: DuckDBModule, final: number, a: number, b:number): void;
     truncateFile(mod: DuckDBModule, fileId: number, newSize: number): void;
     readFile(mod: DuckDBModule, fileId: number, buffer: number, bytes: number, location: number): number;
     writeFile(mod: DuckDBModule, fileId: number, buffer: number, bytes: number, location: number): number;
@@ -184,6 +185,9 @@ export const DEFAULT_RUNTIME: DuckDBRuntime = {
     dropFile: (_mod: DuckDBModule, _fileNamePtr: number, _fileNameLen:number): void => {},
     getLastFileModificationTime: (_mod: DuckDBModule, _fileId: number): number => {
         return 0;
+    },
+    progressUpdate: (_mod: DuckDBModule, _fileId: number, a: number, b: number): void => {
+        return;
     },
     truncateFile: (_mod: DuckDBModule, _fileId: number, _newSize: number): void => {},
     readFile: (_mod: DuckDBModule, _fileId: number, _buffer: number, _bytes: number, _location: number): number => {

--- a/packages/duckdb-wasm/src/bindings/runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime.ts
@@ -142,7 +142,6 @@ export interface DuckDBRuntime {
     closeFile(mod: DuckDBModule, fileId: number): void;
     dropFile(mod: DuckDBModule, fileNamePtr: number, fileNameLen:number): void;
     getLastFileModificationTime(mod: DuckDBModule, fileId: number): number;
-    progressUpdate(mod: DuckDBModule, final: number, a: number, b:number): void;
     truncateFile(mod: DuckDBModule, fileId: number, newSize: number): void;
     readFile(mod: DuckDBModule, fileId: number, buffer: number, bytes: number, location: number): number;
     writeFile(mod: DuckDBModule, fileId: number, buffer: number, bytes: number, location: number): number;
@@ -161,6 +160,9 @@ export interface DuckDBRuntime {
     prepareFileHandle?: (path: string, protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
     prepareFileHandles?: (path: string[], protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
     prepareDBFileHandle?: (path: string, protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
+
+    // Internal API - experimental
+    progressUpdate(final: number, percentage: number, iteration:number): void;
 
     // Call a scalar UDF function
     callScalarUDF(
@@ -186,7 +188,7 @@ export const DEFAULT_RUNTIME: DuckDBRuntime = {
     getLastFileModificationTime: (_mod: DuckDBModule, _fileId: number): number => {
         return 0;
     },
-    progressUpdate: (_mod: DuckDBModule, _fileId: number, a: number, b: number): void => {
+    progressUpdate: (_final: number, _percentage: number, _iteration: number): void => {
         return;
     },
     truncateFile: (_mod: DuckDBModule, _fileId: number, _newSize: number): void => {},

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -687,6 +687,10 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         }
         return 0;
     },
+    progressUpdate: (_mod: DuckDBModule, done: number, a: number, b: number): void => {
+       //postMessage("");
+	console.log("Update progress: ", done, a, b);
+    },
     checkDirectory: (mod: DuckDBModule, pathPtr: number, pathLen: number) => {
         const path = readString(mod, pathPtr, pathLen);
         console.log(`checkDirectory: ${path}`);

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -692,7 +692,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
     },
     progressUpdate: (done: number, percentage: number, repeat: number): void => {
 	if (postMessage) {
-        	postMessage({requestId: 0,  type: WorkerResponseType.PROGRESS_UPDATE,  data: {status: done?"completed":"in-progress", percentage: percentage, repetitions: repeat}});
+            postMessage({requestId: 0,  type: WorkerResponseType.PROGRESS_UPDATE,  data: {status: done?"completed":"in-progress", percentage: percentage, repetitions: repeat}});
 	}
     },
     checkDirectory: (mod: DuckDBModule, pathPtr: number, pathLen: number) => {

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -1,4 +1,7 @@
 import {StatusCode} from '../status';
+import {
+    WorkerResponseType,
+} from '../parallel/worker_request';
 import {addS3Headers, getHTTPUrl} from '../utils';
 
 import {
@@ -687,9 +690,10 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         }
         return 0;
     },
-    progressUpdate: (_mod: DuckDBModule, done: number, a: number, b: number): void => {
-       //postMessage("");
-	console.log("Update progress: ", done, a, b);
+    progressUpdate: (done: number, percentage: number, repeat: number): void => {
+	if (postMessage) {
+        	postMessage({requestId: 0,  type: WorkerResponseType.PROGRESS_UPDATE,  data: {status: done?"completed":"in-progress", percentage: percentage, repetitions: repeat}});
+	}
     },
     checkDirectory: (mod: DuckDBModule, pathPtr: number, pathLen: number) => {
         const path = readString(mod, pathPtr, pathLen);

--- a/packages/duckdb-wasm/src/bindings/runtime_node.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_node.ts
@@ -197,6 +197,9 @@ export const NODE_RUNTIME: DuckDBRuntime & {
         }
         return 0;
     },
+    progressUpdate: (_mod: DuckDBModule, _fileId: number, a: number, b: number): void => {
+        return;
+    },
     getLastFileModificationTime: (mod: DuckDBModule, fileId: number) => {
         try {
             const file = NODE_RUNTIME.resolveFileInfo(mod, fileId);

--- a/packages/duckdb-wasm/src/bindings/runtime_node.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_node.ts
@@ -197,7 +197,7 @@ export const NODE_RUNTIME: DuckDBRuntime & {
         }
         return 0;
     },
-    progressUpdate: (_mod: DuckDBModule, _fileId: number, a: number, b: number): void => {
+    progressUpdate: (_final: number, _percentage: number, _iteration: number): void => {
         return;
     },
     getLastFileModificationTime: (mod: DuckDBModule, fileId: number) => {

--- a/packages/duckdb-wasm/src/log.ts
+++ b/packages/duckdb-wasm/src/log.ts
@@ -41,6 +41,12 @@ export type LogEntry<O, T, E, V> = {
     readonly value: V;
 };
 
+export type ProgressEntry = {
+    readonly status: string;
+    readonly percentage: string;
+    readonly repetitions: string;
+}
+
 export type LogEntryVariant =
     | LogEntry<LogOrigin.BINDINGS, LogTopic.INSTANTIATE, LogEvent.ERROR, string>
     | LogEntry<LogOrigin.BINDINGS, LogTopic.QUERY, LogEvent.START, void>

--- a/packages/duckdb-wasm/src/log.ts
+++ b/packages/duckdb-wasm/src/log.ts
@@ -47,6 +47,9 @@ export type ProgressEntry = {
     readonly repetitions: string;
 }
 
+/** An execution progress handler */
+export type ExecutionProgressHandler = (p: ProgressEntry) => void;
+
 export type LogEntryVariant =
     | LogEntry<LogOrigin.BINDINGS, LogTopic.INSTANTIATE, LogEvent.ERROR, string>
     | LogEntry<LogOrigin.BINDINGS, LogTopic.QUERY, LogEvent.START, void>

--- a/packages/duckdb-wasm/src/parallel/async_bindings.ts
+++ b/packages/duckdb-wasm/src/parallel/async_bindings.ts
@@ -32,6 +32,9 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
     /** Instantiate the module */
     protected _onInstantiationProgress: ((p: InstantiationProgress) => void)[] = [];
 
+    /** Progress callbacks */
+    //protected _onProgressCallback: ((p: InstantiationProgress) => void)[] = [];
+
     /** The logger */
     protected readonly _logger: Logger;
     /** The worker */
@@ -122,6 +125,10 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
         const response = event.data as WorkerResponseVariant;
         switch (response.type) {
             // Request failed?
+            case WorkerResponseType.PROGRESS_UPDATE: {
+		console.log(response.data);
+                return;
+	    }
             case WorkerResponseType.LOG: {
                 this._logger.log(response.data);
                 return;

--- a/packages/duckdb-wasm/src/parallel/async_bindings.ts
+++ b/packages/duckdb-wasm/src/parallel/async_bindings.ts
@@ -18,6 +18,7 @@ import { InstantiationProgress } from '../bindings/progress';
 import { arrowToSQLField } from '../json_typedef';
 import { WebFile } from '../bindings/web_file';
 import { DuckDBDataProtocol } from '../bindings';
+import { ProgressEntry } from '../log';
 
 const TEXT_ENCODER = new TextEncoder();
 
@@ -33,7 +34,7 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
     protected _onInstantiationProgress: ((p: InstantiationProgress) => void)[] = [];
 
     /** Progress callbacks */
-    //protected _onProgressCallback: ((p: InstantiationProgress) => void)[] = [];
+    protected _onExecutionProgress: ((p: ProgressEntry) => void)[] = [];
 
     /** The logger */
     protected readonly _logger: Logger;
@@ -126,7 +127,9 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
         switch (response.type) {
             // Request failed?
             case WorkerResponseType.PROGRESS_UPDATE: {
-		console.log(response.data);
+                for (const p of this._onExecutionProgress) {
+		    p(response.data);
+		}
                 return;
 	    }
             case WorkerResponseType.LOG: {

--- a/packages/duckdb-wasm/src/parallel/async_bindings.ts
+++ b/packages/duckdb-wasm/src/parallel/async_bindings.ts
@@ -128,10 +128,10 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
             // Request failed?
             case WorkerResponseType.PROGRESS_UPDATE: {
                 for (const p of this._onExecutionProgress) {
-		    p(response.data);
+                    p(response.data);
 		}
                 return;
-	    }
+            }
             case WorkerResponseType.LOG: {
                 this._logger.log(response.data);
                 return;

--- a/packages/duckdb-wasm/src/parallel/worker_request.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_request.ts
@@ -1,5 +1,5 @@
 import { CSVInsertOptions, JSONInsertOptions, ArrowInsertOptions } from '../bindings/insert_options';
-import { LogEntryVariant } from '../log';
+import { LogEntryVariant, ProgressEntry } from '../log';
 import { ScriptTokens } from '../bindings/tokens';
 import { FileStatistics } from '../bindings/file_stats';
 import { DuckDBConfig } from '../bindings/config';
@@ -57,6 +57,7 @@ export enum WorkerResponseType {
     FILE_STATISTICS = 'FILE_STATISTICS',
     INSTANTIATE_PROGRESS = 'INSTANTIATE_PROGRESS',
     LOG = 'LOG',
+    PROGRESS_UPDATE = 'PROGRESS_UPDATE',
     OK = 'OK',
     PREPARED_STATEMENT_ID = 'PREPARED_STATEMENT_ID',
     QUERY_PLAN = 'QUERY_PLAN',
@@ -154,6 +155,7 @@ export type WorkerResponseVariant =
     | WorkerResponse<WorkerResponseType.FILE_STATISTICS, FileStatistics>
     | WorkerResponse<WorkerResponseType.INSTANTIATE_PROGRESS, InstantiationProgress>
     | WorkerResponse<WorkerResponseType.LOG, LogEntryVariant>
+    | WorkerResponse<WorkerResponseType.PROGRESS_UPDATE, ProgressEntry>
     | WorkerResponse<WorkerResponseType.OK, null>
     | WorkerResponse<WorkerResponseType.PREPARED_STATEMENT_ID, number>
     | WorkerResponse<WorkerResponseType.QUERY_PLAN, Uint8Array>


### PR DESCRIPTION
Main note is that this allows while busy executing (and so no messages can be received by the worker) messages can still be sent to the main/UI thread.

Missing:
- [ ] Add a demo/test