### PR TITLE
fix(bindings): handle accessMode in runtime bindings with OPFS

### DIFF
--- a/packages/duckdb-wasm/src/bindings/bindings_base.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_base.ts
@@ -1,5 +1,5 @@
 import { DuckDBModule, PThread } from './duckdb_module';
-import { DuckDBConfig } from './config';
+import { DuckDBAccessMode, DuckDBConfig } from './config';
 import { Logger } from '../log';
 import { InstantiationProgress } from './progress';
 import { DuckDBBindings } from './bindings_interface';
@@ -469,9 +469,9 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
         }
         dropResponseBuffers(this.mod);
     }
-    public async prepareFileHandle(fileName: string, protocol: DuckDBDataProtocol): Promise<void> {
+    public async prepareFileHandle(fileName: string, protocol: DuckDBDataProtocol, accessMode?: DuckDBAccessMode): Promise<void> {
         if (protocol === DuckDBDataProtocol.BROWSER_FSACCESS && this._runtime.prepareFileHandles) {
-            const list = await this._runtime.prepareFileHandles([fileName], DuckDBDataProtocol.BROWSER_FSACCESS);
+            const list = await this._runtime.prepareFileHandles([fileName], DuckDBDataProtocol.BROWSER_FSACCESS, accessMode);
             for (const item of list) {
                 const { handle, path: filePath, fromCached } = item;
                 if (!fromCached && handle.getSize()) {
@@ -482,10 +482,10 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
         }
         throw new Error(`prepareFileHandle: unsupported protocol ${protocol}`);
     }
-    /** Prepare a file handle that could only be acquired aschronously */
-    public async prepareDBFileHandle(path: string, protocol: DuckDBDataProtocol): Promise<void> {
+    /** Prepare a file handle that could only be acquired asynchronously */
+    public async prepareDBFileHandle(path: string, protocol: DuckDBDataProtocol, accessMode?: DuckDBAccessMode): Promise<void> {
         if (protocol === DuckDBDataProtocol.BROWSER_FSACCESS && this._runtime.prepareDBFileHandle) {
-            const list = await this._runtime.prepareDBFileHandle(path, DuckDBDataProtocol.BROWSER_FSACCESS);
+            const list = await this._runtime.prepareDBFileHandle(path, DuckDBDataProtocol.BROWSER_FSACCESS, accessMode);
             for (const item of list) {
                 const { handle, path: filePath, fromCached } = item;
                 if (!fromCached && handle.getSize()) {

--- a/packages/duckdb-wasm/src/bindings/bindings_interface.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_interface.ts
@@ -1,4 +1,4 @@
-import { DuckDBConfig, DuckDBConnection, DuckDBDataProtocol, FileStatistics, InstantiationProgress } from '.';
+import { DuckDBAccessMode, DuckDBConfig, DuckDBConnection, DuckDBDataProtocol, FileStatistics, InstantiationProgress } from '.';
 import { CSVInsertOptions, JSONInsertOptions, ArrowInsertOptions } from './insert_options';
 import { ScriptTokens } from './tokens';
 import { WebFile } from './web_file';
@@ -54,8 +54,8 @@ export interface DuckDBBindings {
         protocol: DuckDBDataProtocol,
         directIO: boolean,
     ): Promise<HandleType>;
-    prepareFileHandle(path: string, protocol: DuckDBDataProtocol): Promise<void>;
-    prepareDBFileHandle(path: string, protocol: DuckDBDataProtocol): Promise<void>;
+    prepareFileHandle(path: string, protocol: DuckDBDataProtocol, accessMode?: DuckDBAccessMode): Promise<void>;
+    prepareDBFileHandle(path: string, protocol: DuckDBDataProtocol, accessMode?: DuckDBAccessMode): Promise<void>;
     globFiles(path: string): WebFile[];
     dropFile(name: string): void;
     dropFiles(): void;

--- a/packages/duckdb-wasm/src/bindings/runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime.ts
@@ -1,6 +1,9 @@
+import { DuckDBAccessMode } from './config';
 import { DuckDBModule } from './duckdb_module';
 import { UDFFunction } from './udf_function';
 import * as udf_rt from './udf_runtime';
+
+export { DuckDBAccessMode };
 
 /** Wrapper for TextDecoder to support shared array buffers */
 function TextDecoderWrapper(): (input?: BufferSource) => string {
@@ -156,10 +159,10 @@ export interface DuckDBRuntime {
     checkFile(mod: DuckDBModule, pathPtr: number, pathLen: number): boolean;
     removeFile(mod: DuckDBModule, pathPtr: number, pathLen: number): void;
 
-    // Prepare a file handle that could only be acquired aschronously
-    prepareFileHandle?: (path: string, protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
-    prepareFileHandles?: (path: string[], protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
-    prepareDBFileHandle?: (path: string, protocol: DuckDBDataProtocol) => Promise<PreparedDBFileHandle[]>;
+    // Prepare a file handle that could only be acquired asynchronously
+    prepareFileHandle?: (path: string, protocol: DuckDBDataProtocol, accessMode?: DuckDBAccessMode) => Promise<PreparedDBFileHandle[]>;
+    prepareFileHandles?: (path: string[], protocol: DuckDBDataProtocol, accessMode?: DuckDBAccessMode) => Promise<PreparedDBFileHandle[]>;
+    prepareDBFileHandle?: (path: string, protocol: DuckDBDataProtocol, accessMode?: DuckDBAccessMode) => Promise<PreparedDBFileHandle[]>;
 
     // Call a scalar UDF function
     callScalarUDF(

--- a/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
@@ -136,8 +136,9 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
 
                 case WorkerRequestType.OPEN: {
                     const path = request.data.path;
+                    const accessMode = request.data.accessMode;
                     if (path?.startsWith('opfs://')) {
-                        await this._bindings.prepareDBFileHandle(path, DuckDBDataProtocol.BROWSER_FSACCESS);
+                        await this._bindings.prepareDBFileHandle(path, DuckDBDataProtocol.BROWSER_FSACCESS, accessMode);
                         request.data.useDirectIO = true;
                     }
                     this._bindings.open(request.data);

--- a/packages/duckdb-wasm/test/opfs.test.ts
+++ b/packages/duckdb-wasm/test/opfs.test.ts
@@ -278,30 +278,75 @@ export function testOPFS(baseDir: string, bundle: () => duckdb.DuckDBBundle): vo
         });
     });
 
+    describe('Open database in OPFS', () => {
+        it('should not open a non-existent DB file in read-only', async () => {
+            const logger = new duckdb.ConsoleLogger(LogLevel.ERROR);
+            const worker = new Worker(bundle().mainWorker!);
+            const db_ = new duckdb.AsyncDuckDB(logger, worker);
+            await db_.instantiate(bundle().mainModule, bundle().pthreadWorker);
+
+            await expectAsync(db_.open({
+                path: 'opfs://non_existent.db',
+                accessMode: duckdb.DuckDBAccessMode.READ_ONLY,
+            })).toBeRejectedWithError(Error, /file or directory could not be found/);
+
+            await db_.terminate();
+            await worker.terminate();
+
+            // Files should not be found with DuckDBAccessMode.READ_ONLY
+            const opfsRoot = await navigator.storage.getDirectory();
+            await expectAsync(opfsRoot.getFileHandle('non_existent.db', { create: false }))
+                .toBeRejectedWithError(Error, /file or directory could not be found/);
+        });
+
+        it('should open a non-existent DB file in read-write and create files', async () => {
+            const logger = new duckdb.ConsoleLogger(LogLevel.ERROR);
+            const worker = new Worker(bundle().mainWorker!);
+            const db_ = new duckdb.AsyncDuckDB(logger, worker);
+            await db_.instantiate(bundle().mainModule, bundle().pthreadWorker);
+
+            const opfsRoot = await navigator.storage.getDirectory();
+
+            // Ensure files do not exist
+            await expectAsync(opfsRoot.getFileHandle('non_existent_2.db', { create: false }))
+                .toBeRejectedWithError(Error, /file or directory could not be found/);
+            await expectAsync(opfsRoot.getFileHandle('non_existent_2.db.wal', { create: false }))
+                .toBeRejectedWithError(Error, /file or directory could not be found/);
+
+            await expectAsync(db_.open({
+                path: 'opfs://non_existent_2.db',
+                accessMode: duckdb.DuckDBAccessMode.READ_WRITE,
+            })).toBeResolved();
+
+            await db_.terminate();
+            await worker.terminate();
+
+            // Files should be found with DuckDBAccessMode.READ_WRITE
+            await expectAsync(opfsRoot.getFileHandle('non_existent_2.db', { create: false })).toBeResolved();
+            await expectAsync(opfsRoot.getFileHandle('non_existent_2.db.wal', { create: false })).toBeResolved();
+        });
+    })
+
     async function removeFiles() {
         const opfsRoot = await navigator.storage.getDirectory();
-        await opfsRoot.removeEntry('test.db').catch(() => {
-        });
-        await opfsRoot.removeEntry('test.db.wal').catch(() => {
-        });
-        await opfsRoot.removeEntry('test.csv').catch(() => {
-        });
-        await opfsRoot.removeEntry('test1.csv').catch(() => {
-        });
-        await opfsRoot.removeEntry('test2.csv').catch(() => {
-        });
-        await opfsRoot.removeEntry('test3.csv').catch(() => {
-        });
-        await opfsRoot.removeEntry('test.parquet').catch(() => {
-        });
+        await opfsRoot.removeEntry('test.db').catch(() => {});
+        await opfsRoot.removeEntry('test.db.wal').catch(() => {});
+        await opfsRoot.removeEntry('test.csv').catch(() => {});
+        await opfsRoot.removeEntry('test1.csv').catch(() => {});
+        await opfsRoot.removeEntry('test2.csv').catch(() => {});
+        await opfsRoot.removeEntry('test3.csv').catch(() => {});
+        await opfsRoot.removeEntry('test.parquet').catch(() => {});
         try {
             const datadir = await opfsRoot.getDirectoryHandle('datadir');
-            datadir.removeEntry('test.parquet').catch(() => {
-            });
+            datadir.removeEntry('test.parquet').catch(() => {});
         } catch (e) {
             //
         }
-        await opfsRoot.removeEntry('datadir').catch(() => {
-        });
+        await opfsRoot.removeEntry('datadir').catch(() => {});
+        // In case of failure caused leftovers
+        await opfsRoot.removeEntry('non_existent.db').catch(() => {});
+        await opfsRoot.removeEntry('non_existent.db.wal').catch(() => {});
+        await opfsRoot.removeEntry('non_existent_2.db').catch(() => {});
+        await opfsRoot.removeEntry('non_existent_2.db.wal').catch(() => {});
     }
 }


### PR DESCRIPTION
> This is an amazing project with many great works. Thank you

# Context

During my recent usage with `duckdb-wasm` with the recent OPFS support done by @e1arikawa (Thank you for the cool work!), I encountered an issue where the file/directory handles were always created even when I opened the database with read-only options like:

```js
db.open({
    path: 'opfs://not_yet_existing.db',
    accessMode: DuckDBAccessMode.READ_ONLY, // We should NOT create any files/directories
})
```

# Summary

Going deeper, it seems we didn't handle the `accessMode` in helper functions like `prepareFileHandles`. Therefore, in this pull request, I tried to add the missing parameters to these functions as optional ones and added several test cases for open operations as such with different `accessMode` in OPFS.