### PR TITLE
Added a Check for the Worker is Running or Not

### DIFF
--- a/packages/duckdb-wasm/src/bindings/connection.ts
+++ b/packages/duckdb-wasm/src/bindings/connection.ts
@@ -46,7 +46,14 @@ export class DuckDBConnection {
                     resolve(this._bindings.pollPendingQuery(this._conn));
                 } catch (e: any) {
                     console.log(e);
-                    reject(e);
+                    // If the worker is not set, the worker has been terminated
+                    if (e.message.includes('worker is not set!')) {
+                        reject(new Error('Worker has been terminated'));
+                    } else {
+                        //Otherwise, reject with the error
+                        reject(e);
+                    }
+                    
                 }
             });
         }


### PR DESCRIPTION
Fixes #1970

This pull request includes an important change to the error handling in the `DuckDBConnection` class within the `connection.ts` file. The change improves the handling of specific error messages related to worker termination.

Error handling improvement:

* [`packages/duckdb-wasm/src/bindings/connection.ts`](diffhunk://#diff-34de9050bae040fbfa05ede411b102748cc85f40311763fe461a0a6446208e49R49-R57): Added a check for the error message "worker is not set!" to provide a more specific error message indicating that the worker has been terminated.