### PR TITLE
Make sure we `Fetch` query result when ready

### DIFF
--- a/lib/include/duckdb/web/webdb.h
+++ b/lib/include/duckdb/web/webdb.h
@@ -33,12 +33,14 @@ struct DuckDBWasmResultsWrapper {
     // Additional ResponseStatuses to be >= 256, and mirrored to packages/duckdb-wasm/src/status.ts
     // Missing mapping result in a throw, but they should eventually align (it's fine if typescript side only has a
     // subset)
-    enum ResponseStatus : uint32_t { ARROW_BUFFER = 0, MAX_ARROW_ERROR = 255 };
+    enum ResponseStatus : uint32_t { ARROW_BUFFER = 0, MAX_ARROW_ERROR = 255, DUCKDB_WASM_RETRY = 256 };
     DuckDBWasmResultsWrapper(arrow::Result<std::shared_ptr<arrow::Buffer>> res,
                              ResponseStatus status = ResponseStatus::ARROW_BUFFER)
         : arrow_buffer(res), status(status) {}
     DuckDBWasmResultsWrapper(arrow::Status res, ResponseStatus status = ResponseStatus::ARROW_BUFFER)
         : arrow_buffer(res), status(status) {}
+    DuckDBWasmResultsWrapper(ResponseStatus status = ResponseStatus::ARROW_BUFFER)
+        : DuckDBWasmResultsWrapper(nullptr, status) {}
     arrow::Result<std::shared_ptr<arrow::Buffer>> arrow_buffer;
     ResponseStatus status;
 };

--- a/lib/src/webdb.cc
+++ b/lib/src/webdb.cc
@@ -74,8 +74,6 @@ namespace web {
 
 static constexpr int64_t DEFAULT_QUERY_POLLING_INTERVAL = 100;
 
-static uint8_t MAGIC_BYTE_RETRY = 84;
-
 /// Create the default webdb database
 duckdb::unique_ptr<WebDB> WebDB::Create() {
     if constexpr (ENVIRONMENT == Environment::WEB) {
@@ -265,9 +263,9 @@ DuckDBWasmResultsWrapper WebDB::Connection::FetchQueryResults() {
                         break;
                     case StreamExecutionResult::BLOCKED:
                         stream_result.WaitForTask();
-                        return arrow::Buffer::Wrap<uint8_t>(&MAGIC_BYTE_RETRY, 1);
+                        return DuckDBWasmResultsWrapper::ResponseStatus::DUCKDB_WASM_RETRY;
                     case StreamExecutionResult::NO_TASKS_AVAILABLE:
-                        return arrow::Buffer::Wrap<uint8_t>(&MAGIC_BYTE_RETRY, 1);
+                        return DuckDBWasmResultsWrapper::ResponseStatus::DUCKDB_WASM_RETRY;
                     case StreamExecutionResult::CHUNK_NOT_READY:
                         break;
                 }
@@ -277,7 +275,7 @@ DuckDBWasmResultsWrapper WebDB::Connection::FetchQueryResults() {
             } while (!ready && elapsed < polling_interval);
 
             if (!ready) {
-                return arrow::Buffer::Wrap<uint8_t>(&MAGIC_BYTE_RETRY, 1);
+                return DuckDBWasmResultsWrapper::ResponseStatus::DUCKDB_WASM_RETRY;
             }
         }
 

--- a/packages/duckdb-wasm/src/bindings/bindings_base.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_base.ts
@@ -4,7 +4,7 @@ import { Logger } from '../log';
 import { InstantiationProgress } from './progress';
 import { DuckDBBindings } from './bindings_interface';
 import { DuckDBConnection } from './connection';
-import { StatusCode, IsArrowBuffer } from '../status';
+import { StatusCode, IsArrowBuffer, IsDuckDBWasmRetry } from '../status';
 import { dropResponseBuffers, DuckDBRuntime, readString, callSRet, copyBuffer, DuckDBDataProtocol } from './runtime';
 import { CSVInsertOptions, JSONInsertOptions, ArrowInsertOptions } from './insert_options';
 import { ScriptTokens } from './tokens';
@@ -224,6 +224,11 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
     /** Fetch query results */
     public fetchQueryResults(conn: number): Uint8Array | null {
         const [s, d, n] = callSRet(this.mod, 'duckdb_web_query_fetch_results', ['number'], [conn]);
+        if (IsDuckDBWasmRetry(s)) {
+            dropResponseBuffers(this.mod);
+            return null; // Retry
+        }
+
         if (!IsArrowBuffer(s)) {
             throw new Error("Unexpected StatusCode from duckdb_web_query_fetch_results (" + s + ") and with self reported error as" + readString(this.mod, d, n));
         }
@@ -233,11 +238,6 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
 
         const res = copyBuffer(this.mod, d, n);
         dropResponseBuffers(this.mod);
-
-        // Special case indicating to the caller they need to retry
-        if (res.length === 1 && res[0] == 84) {
-            return null;
-        }
         return res;
     }
     /** Get table names */

--- a/packages/duckdb-wasm/src/bindings/bindings_interface.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_interface.ts
@@ -19,7 +19,7 @@ export interface DuckDBBindings {
     startPendingQuery(conn: number, text: string, allowStreamResult: boolean): Uint8Array | null;
     pollPendingQuery(conn: number): Uint8Array | null;
     cancelPendingQuery(conn: number): boolean;
-    fetchQueryResults(conn: number): Uint8Array;
+    fetchQueryResults(conn: number): Uint8Array | null;
     getTableNames(conn: number, text: string): string[];
 
     createPrepared(conn: number, text: string): number;

--- a/packages/duckdb-wasm/src/bindings/connection.ts
+++ b/packages/duckdb-wasm/src/bindings/connection.ts
@@ -53,7 +53,6 @@ export class DuckDBConnection {
                         //Otherwise, reject with the error
                         reject(e);
                     }
-                    
                 }
             });
         }
@@ -125,7 +124,10 @@ export class ResultStreamIterator implements Iterable<Uint8Array> {
         if (this._depleted) {
             return { done: true, value: null };
         }
-        const bufferI8 = this.bindings.fetchQueryResults(this.conn);
+        let bufferI8 = null;
+        do {
+            bufferI8 = this.bindings.fetchQueryResults(this.conn);
+        } while (bufferI8 == null);
         this._depleted = bufferI8.length == 0;
         return {
             done: this._depleted,

--- a/packages/duckdb-wasm/src/parallel/async_bindings.ts
+++ b/packages/duckdb-wasm/src/parallel/async_bindings.ts
@@ -442,8 +442,8 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
     }
 
     /** Fetch query results */
-    public async fetchQueryResults(conn: ConnectionID): Promise<Uint8Array> {
-        const task = new WorkerTask<WorkerRequestType.FETCH_QUERY_RESULTS, ConnectionID, Uint8Array>(
+    public async fetchQueryResults(conn: ConnectionID): Promise<Uint8Array | null> {
+        const task = new WorkerTask<WorkerRequestType.FETCH_QUERY_RESULTS, ConnectionID, Uint8Array | null>(
             WorkerRequestType.FETCH_QUERY_RESULTS,
             conn,
         );

--- a/packages/duckdb-wasm/src/parallel/async_bindings_interface.ts
+++ b/packages/duckdb-wasm/src/parallel/async_bindings_interface.ts
@@ -22,7 +22,7 @@ export interface AsyncDuckDBBindings {
     startPendingQuery(conn: number, text: string, allowStreamResult: boolean): Promise<Uint8Array | null>;
     pollPendingQuery(conn: number): Promise<Uint8Array | null>;
     cancelPendingQuery(conn: number): Promise<boolean>;
-    fetchQueryResults(conn: number): Promise<Uint8Array>;
+    fetchQueryResults(conn: number): Promise<Uint8Array | null>;
 
     createPrepared(conn: number, text: string): Promise<number>;
     closePrepared(conn: number, statement: number): Promise<void>;

--- a/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
@@ -279,6 +279,7 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
                 }
                 case WorkerRequestType.FETCH_QUERY_RESULTS: {
                     const result = this._bindings.fetchQueryResults(request.data);
+                    const transfer = result ? [result.buffer] : [];
                     this.postMessage(
                         {
                             messageId: this._nextMessageId++,
@@ -286,7 +287,7 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
                             type: WorkerResponseType.QUERY_RESULT_CHUNK,
                             data: result,
                         },
-                        [result.buffer],
+                        transfer,
                     );
                     break;
                 }

--- a/packages/duckdb-wasm/src/parallel/worker_request.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_request.ts
@@ -160,7 +160,7 @@ export type WorkerResponseVariant =
     | WorkerResponse<WorkerResponseType.PREPARED_STATEMENT_ID, number>
     | WorkerResponse<WorkerResponseType.QUERY_PLAN, Uint8Array>
     | WorkerResponse<WorkerResponseType.QUERY_RESULT, Uint8Array>
-    | WorkerResponse<WorkerResponseType.QUERY_RESULT_CHUNK, Uint8Array>
+    | WorkerResponse<WorkerResponseType.QUERY_RESULT_CHUNK, Uint8Array | null>
     | WorkerResponse<WorkerResponseType.QUERY_RESULT_HEADER, Uint8Array>
     | WorkerResponse<WorkerResponseType.QUERY_RESULT_HEADER_OR_NULL, Uint8Array | null>
     | WorkerResponse<WorkerResponseType.SCRIPT_TOKENS, ScriptTokens>
@@ -180,7 +180,7 @@ export type WorkerTaskVariant =
     | WorkerTask<WorkerRequestType.DROP_FILE, string, null>
     | WorkerTask<WorkerRequestType.DROP_FILES, null, null>
     | WorkerTask<WorkerRequestType.EXPORT_FILE_STATISTICS, string, FileStatistics>
-    | WorkerTask<WorkerRequestType.FETCH_QUERY_RESULTS, ConnectionID, Uint8Array>
+    | WorkerTask<WorkerRequestType.FETCH_QUERY_RESULTS, ConnectionID, Uint8Array | null>
     | WorkerTask<WorkerRequestType.FLUSH_FILES, null, null>
     | WorkerTask<WorkerRequestType.GET_FEATURE_FLAGS, null, number>
     | WorkerTask<WorkerRequestType.GET_TABLE_NAMES, [number, string], string[]>

--- a/packages/duckdb-wasm/src/status.ts
+++ b/packages/duckdb-wasm/src/status.ts
@@ -1,8 +1,13 @@
 export enum StatusCode {
   SUCCESS = 0,
   MAX_ARROW_ERROR = 255,
+  DUCKDB_WASM_RETRY = 256,
 }
 
 export function IsArrowBuffer(status: StatusCode): boolean {
-  return (status <= StatusCode.MAX_ARROW_ERROR);
+  return status <= StatusCode.MAX_ARROW_ERROR;
+}
+
+export function IsDuckDBWasmRetry(status: StatusCode): boolean {
+  return status === StatusCode.DUCKDB_WASM_RETRY;
 }


### PR DESCRIPTION
In the current code, we call `Fetch` on a query result before checking if there is a result available, which may cause deadlocks since we don't return to the event loop in the `BLOCKED` and `NO_TASKS_AVAILABLE` cases.

This PR solves it by returning a special buffer containing one "magic" byte out of the C++ layer, then a `null` buffer indicating the caller they need to retry fetching.

We tested this with MotherDuck operators which do return "BLOCKED", and this fixes the streaming issue we had.

Ideally, this would test this with a custom "test" extension that reproduces the behavior.

Another way to test it (albeit less ideal), would be to run DuckDB Wasm tests with a special version of DuckDB compiled with `FORCE_ASYNC_SINK_SOURCE` flag.