### PR TITLE
Wrap results of fetchQueryResults via DuckDBWasmResultsWrapper

### DIFF
--- a/lib/include/duckdb/web/utils/wasm_response.h
+++ b/lib/include/duckdb/web/utils/wasm_response.h
@@ -8,6 +8,8 @@
 namespace duckdb {
 namespace web {
 
+struct DuckDBWasmResultsWrapper;
+
 struct WASMResponse {
     /// The status code
     double statusCode = 1;
@@ -35,6 +37,8 @@ class WASMResponseBuffer {
     /// Store the arrow status.
     /// Returns wheather the result was OK
     bool Store(WASMResponse& response, arrow::Status status);
+    /// Store a DuckDBWasmResultsWrapper
+    void Store(WASMResponse& response, DuckDBWasmResultsWrapper& value);
     /// Store a string
     void Store(WASMResponse& response, std::string value);
     /// Store a string view

--- a/lib/src/utils/wasm_response.cc
+++ b/lib/src/utils/wasm_response.cc
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "arrow/buffer.h"
+#include "duckdb/web/webdb.h"
 
 namespace duckdb {
 namespace web {
@@ -24,6 +25,15 @@ bool WASMResponseBuffer::Store(WASMResponse& response, arrow::Status status) {
         return false;
     }
     return true;
+}
+
+void WASMResponseBuffer::Store(WASMResponse& response, DuckDBWasmResultsWrapper& value) {
+    if (value.status == DuckDBWasmResultsWrapper::ResponseStatus::ARROW_BUFFER) {
+        Store(response, std::move(value.arrow_buffer));
+    } else {
+        Clear();
+        response.statusCode = value.status;
+    }
 }
 
 void WASMResponseBuffer::Store(WASMResponse& response, std::string value) {

--- a/lib/src/webdb.cc
+++ b/lib/src/webdb.cc
@@ -231,12 +231,12 @@ bool WebDB::Connection::CancelPendingQuery() {
     }
 }
 
-arrow::Result<std::shared_ptr<arrow::Buffer>> WebDB::Connection::FetchQueryResults() {
+DuckDBWasmResultsWrapper WebDB::Connection::FetchQueryResults() {
     try {
         // Fetch data if a query is active
         duckdb::unique_ptr<duckdb::DataChunk> chunk;
         if (current_query_result_ == nullptr) {
-            return nullptr;
+            return DuckDBWasmResultsWrapper{nullptr};
         }
         // Fetch next result chunk
         chunk = current_query_result_->Fetch();
@@ -248,7 +248,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> WebDB::Connection::FetchQueryResul
             current_query_result_.reset();
             current_schema_.reset();
             current_schema_patched_.reset();
-            return nullptr;
+            return DuckDBWasmResultsWrapper{nullptr};
         }
 
         // Serialize the record batch

--- a/lib/src/webdb_api.cc
+++ b/lib/src/webdb_api.cc
@@ -241,7 +241,7 @@ bool duckdb_web_pending_query_cancel(ConnectionHdl connHdl, const char* script) 
 void duckdb_web_query_fetch_results(WASMResponse* packed, ConnectionHdl connHdl) {
     auto c = reinterpret_cast<WebDB::Connection*>(connHdl);
     auto r = c->FetchQueryResults();
-    WASMResponseBuffer::Get().Store(*packed, std::move(r));
+    WASMResponseBuffer::Get().Store(*packed, r);
 }
 /// Get table names
 void duckdb_web_get_tablenames(WASMResponse* packed, ConnectionHdl connHdl, const char* query) {

--- a/packages/duckdb-wasm/src/bindings/bindings_base.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_base.ts
@@ -4,7 +4,7 @@ import { Logger } from '../log';
 import { InstantiationProgress } from './progress';
 import { DuckDBBindings } from './bindings_interface';
 import { DuckDBConnection } from './connection';
-import { StatusCode } from '../status';
+import { StatusCode, IsArrowBuffer } from '../status';
 import { dropResponseBuffers, DuckDBRuntime, readString, callSRet, copyBuffer, DuckDBDataProtocol } from './runtime';
 import { CSVInsertOptions, JSONInsertOptions, ArrowInsertOptions } from './insert_options';
 import { ScriptTokens } from './tokens';
@@ -224,6 +224,9 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
     /** Fetch query results */
     public fetchQueryResults(conn: number): Uint8Array {
         const [s, d, n] = callSRet(this.mod, 'duckdb_web_query_fetch_results', ['number'], [conn]);
+        if (!IsArrowBuffer(s)) {
+            throw new Error("Unexpected StatusCode from duckdb_web_query_fetch_results (" + s + ") and with self reported error as" + readString(this.mod, d, n));
+        }
         if (s !== StatusCode.SUCCESS) {
             throw new Error(readString(this.mod, d, n));
         }

--- a/packages/duckdb-wasm/src/status.ts
+++ b/packages/duckdb-wasm/src/status.ts
@@ -1,3 +1,8 @@
 export enum StatusCode {
-    SUCCESS = 0,
+  SUCCESS = 0,
+  MAX_ARROW_ERROR = 255,
+}
+
+export function IsArrowBuffer(status: StatusCode): boolean {
+  return (status <= StatusCode.MAX_ARROW_ERROR);
 }


### PR DESCRIPTION
This is currently just adding infrastructure, there should be no relevant changes

Note that enum added to lib/include/duckdb/web/webdb.h would evetntually need to be dupliciated also to packages/duckdb-wasm/src/status.ts