### PR TITLE
Fix minor typo in duckdb-wasm/README.md

### DIFF
--- a/packages/duckdb-wasm/README.md
+++ b/packages/duckdb-wasm/README.md
@@ -100,7 +100,7 @@ const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     },
 };
 // Select a bundle based on browser checks
-const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
 // Instantiate the asynchronous version of DuckDB-wasm
 const worker = new Worker(bundle.mainWorker!);
 const logger = new duckdb.ConsoleLogger();


### PR DESCRIPTION
Bundles are defined as `MANUAL_BUNDLES` so `selectBundle` should receive `MANUAL_BUNDLES` instead of `JSDELIVR_BUNDLES`, I suppose.

Adding context, I'm not very sure this fix. I'm not familiar with WASM and Web Workers at all. I'm still struggling setting up duckdb-wasm with Vite 😓. 
Just reading the example and guessing with JavaScript knowledge, I consider it won't work and suggest a fix anyway.