### PR TITLE
Avoid failure while globbing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ update_exported_list:
 	cd build/relsize/${TARGET} && wasm2wat duckdb_wasm.wasm --enable-all -o duckdb-wasm.wat
 	cd build/relsize/${TARGET} && grep export duckdb-wasm.wat | cut -d \" -f2 | sed '$d' | grep -v "^orig" | grep -v "^dynCall_" > export_list.txt
         ## filter list of c++ symbols
-	cd build/relsize/${TARGET} && cat export_list.txt | grep "^_" | grep -v "_Unwind_" | grep -v "__syscall_shutdown" | grep -v "0\\00\\0" | grep -v "^_ZZN5arrow" | grep -v "^_ZGVZN5arrow" | grep -v "^_ZN5arrow" | sort > cpp_list
+	cd build/relsize/${TARGET} && cat export_list.txt | grep "^_" | grep -v "_Unwind_DeleteException" | grep -v "_Unwind_RaiseException" | grep -v "__syscall_shutdown" | grep -v "0\\00\\0" | grep -v "^_ZZN5arrow" | grep -v "^_ZGVZN5arrow" | grep -v "^_ZN5arrow" | sort > cpp_list
 	cd build/relsize/${TARGET} && sed 's/^/_/g' cpp_list > exported_list.txt
         ## filter list of c symbols
 	cd build/relsize/${TARGET} && cat export_list.txt | grep -v "^_" | grep -v "getTempRet" | grep -v "^sched_yield" | grep -v "emscripten_wget" | grep -v "0\\00\\0" | sort > c_exported_list

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -432,7 +432,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                     // https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/s3-example-presigned-urls.html
                     // so we need (if enabled) to bump to a ranged GET
                     if (!BROWSER_RUNTIME.getGlobalFileInfo(mod)?.allowFullHttpReads) {
-                        failWith(mod, `HEAD request failed: ${path}, with full http reads are disabled`);
+                        console.log(`HEAD request failed: ${path}, with full http reads are disabled`);
                         return 0;
                     }
                     const xhr2 = new XMLHttpRequest();
@@ -446,7 +446,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                     xhr2.setRequestHeader('Range', `bytes=0-0`);
                     xhr2.send(null);
                     if (xhr2.status != 200 && xhr2.status !== 206) {
-                        failWith(mod, `HEAD and GET requests failed: ${path}`);
+                        console.log(`HEAD and GET requests failed: ${path}`);
                         return 0;
                     }
                     const contentLength = xhr2.getResponseHeader('Content-Length');


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-wasm/issues/2005

This needs to be refined and likely generalized, but starting with fixing the problem at hand.

Test case is like:
```
LOAD spatial;
CREATE TABLE nyc AS SELECT * FROM ST_READ('https://raw.githubusercontent.com/duckdb/duckdb-spatial/main/test/data/nyc_taxi/taxi_zones/taxi_zones.shp');
```
That currently throws while it should correctly return 263 rows. 