### PR TITLE
bump js-sha256 from 0.11.0 to 0.11.1

### DIFF
--- a/packages/duckdb-wasm/package.json
+++ b/packages/duckdb-wasm/package.json
@@ -38,7 +38,7 @@
         "jasmine": "^5.1.0",
         "jasmine-core": "^5.1.2",
         "jasmine-spec-reporter": "^7.0.0",
-        "js-sha256": "^0.11.0",
+        "js-sha256": "^0.11.1",
         "karma": "^6.4.2",
         "karma-chrome-launcher": "^3.2.0",
         "karma-coverage": "^2.2.1",

--- a/packages/duckdb-wasm/src/utils/s3_helper.ts
+++ b/packages/duckdb-wasm/src/utils/s3_helper.ts
@@ -143,23 +143,12 @@ export function createS3Headers(params: S3Params, payloadParams: S3PayloadParams
         '/aws4_request\n' +
         canonicalRequestHashStr;
 
-    // ts-ignore's because library can accept array buffer as key, but TS arg is incorrect
     const signKey = 'AWS4' + params.secretAccessKey;
     const kDate = sha256.hmac.arrayBuffer(signKey, params.dateNow);
 
-    // Note, js-sha256 has a bug in the TS interface that only supports strings as keys, while we need a bytearray
-    // as key. PR is open but unmerged: https://github.com/emn178/js-sha256/pull/25
-    // eslint-disable-next-line
-    // @ts-ignore
     const kRegion = sha256.hmac.arrayBuffer(kDate, params.region);
-    // eslint-disable-next-line
-    // @ts-ignore
     const kService = sha256.hmac.arrayBuffer(kRegion, params.service);
-    // eslint-disable-next-line
-    // @ts-ignore
     const signingKey = sha256.hmac.arrayBuffer(kService, 'aws4_request');
-    // eslint-disable-next-line
-    // @ts-ignore
     const signature = sha256.hmac(signingKey, stringToSign);
 
     res.set(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5113,10 +5113,10 @@ js-cookie@^3.0.5:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
   integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
-js-sha256@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.0.tgz#256a921d9292f7fe98905face82e367abaca9576"
-  integrity sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==
+js-sha256@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.1.tgz#712262e8fc9569d6f7f6eea72c0d8e5ccc7c976c"
+  integrity sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
PR bumps the [`js-sha256`](https://github.com/emn178/js-sha256) dependency to 0.11.1, which fixes checking for the node environment when running in electron browser.

I also was able to remove some type ignores from the codebase as the issue was fixed in the 0.10.0 release.

Closes #1432