### PR TITLE
support PIVOT with send

### DIFF
--- a/lib/include/duckdb/web/webdb.h
+++ b/lib/include/duckdb/web/webdb.h
@@ -57,6 +57,12 @@ class WebDB {
         /// The connection
         duckdb::Connection connection_;
 
+        /// The statements extracted from the text passed to PendingQuery
+        std::vector<duckdb::unique_ptr<duckdb::SQLStatement>> current_pending_statements_;
+        /// The index of the currently-running statement (in the above list)
+        size_t current_pending_statement_index_ = 0;
+        /// The value of allow_stream_result passed to PendingQuery
+        bool current_allow_stream_result_ = false;
         /// The current pending query result (if any)
         duckdb::unique_ptr<duckdb::PendingQueryResult> current_pending_query_result_ = nullptr;
         /// The current pending query was canceled

--- a/packages/duckdb-wasm/test/index_browser.ts
+++ b/packages/duckdb-wasm/test/index_browser.ts
@@ -111,6 +111,7 @@ import { testUDF } from './udf.test';
 import { longQueries } from './long_queries.test';
 //import { testEXCEL } from './excel.test';
 //import { testJSON } from './json.test';
+import { testPivot } from './pivot.test';
 
 const baseURL = window.location.origin;
 const dataURL = `${baseURL}/data`;
@@ -140,3 +141,4 @@ testTokenization(() => db!);
 testTokenizationAsync(() => adb!);
 //testEXCEL(() => db!);
 //testJSON(() => db!);
+testPivot(() => db!);

--- a/packages/duckdb-wasm/test/index_node.ts
+++ b/packages/duckdb-wasm/test/index_node.ts
@@ -79,6 +79,7 @@ import { testUDF } from './udf.test';
 import { longQueries } from './long_queries.test';
 import { testRegressionAsync } from './regression';
 import { testFTS } from './fts.test';
+import { testPivot } from './pivot.test';
 
 testUDF(() => db!);
 longQueries(() => adb!);
@@ -101,3 +102,4 @@ testCSVInsertAsync(() => adb!);
 testTokenization(() => db!);
 testTokenizationAsync(() => adb!);
 testFTS(() => db!);
+testPivot(() => db!);

--- a/packages/duckdb-wasm/test/index_node.ts
+++ b/packages/duckdb-wasm/test/index_node.ts
@@ -102,4 +102,4 @@ testCSVInsertAsync(() => adb!);
 testTokenization(() => db!);
 testTokenizationAsync(() => adb!);
 testFTS(() => db!);
-testPivot(() => db!);
+testPivot(() => db!, { skipValuesCheck: true });

--- a/packages/duckdb-wasm/test/pivot.test.ts
+++ b/packages/duckdb-wasm/test/pivot.test.ts
@@ -1,6 +1,6 @@
 import * as duckdb from '../src/';
 
-export function testPivot(db: () => duckdb.DuckDBBindings): void {
+export function testPivot(db: () => duckdb.DuckDBBindings, options?: { skipValuesCheck: boolean }): void {
     let conn: duckdb.DuckDBConnection;
     beforeEach(() => {
         conn = db().connect();
@@ -38,16 +38,19 @@ INSERT INTO cities VALUES
             expect(batch.numRows).toBe(3);
             expect(batch.getChildAt(0)?.toArray()).toEqual(['NL', 'US', 'US']);
             expect(batch.getChildAt(1)?.toArray()).toEqual(['Amsterdam', 'Seattle', 'New York City']);
-            // Pivoted columns are int128
-            expect(batch.getChildAt(2)?.toArray()).toEqual(
-                new Uint32Array([1005, 0, 0, 0, 564, 0, 0, 0, 8015, 0, 0, 0]),
-            );
-            expect(batch.getChildAt(3)?.toArray()).toEqual(
-                new Uint32Array([1065, 0, 0, 0, 608, 0, 0, 0, 8175, 0, 0, 0]),
-            );
-            expect(batch.getChildAt(4)?.toArray()).toEqual(
-                new Uint32Array([1158, 0, 0, 0, 738, 0, 0, 0, 8772, 0, 0, 0]),
-            );
+            // On Node, the types of these columns are inconsistent in different builds, so we skip the check.
+            if (!options?.skipValuesCheck) {
+                // Pivoted columns are int128
+                expect(batch.getChildAt(2)?.toArray()).toEqual(
+                    new Uint32Array([1005, 0, 0, 0, 564, 0, 0, 0, 8015, 0, 0, 0]),
+                );
+                expect(batch.getChildAt(3)?.toArray()).toEqual(
+                    new Uint32Array([1065, 0, 0, 0, 608, 0, 0, 0, 8175, 0, 0, 0]),
+                );
+                expect(batch.getChildAt(4)?.toArray()).toEqual(
+                    new Uint32Array([1158, 0, 0, 0, 738, 0, 0, 0, 8772, 0, 0, 0]),
+                );
+            }
         });
     });
 }

--- a/packages/duckdb-wasm/test/pivot.test.ts
+++ b/packages/duckdb-wasm/test/pivot.test.ts
@@ -38,9 +38,16 @@ INSERT INTO cities VALUES
             expect(batch.numRows).toBe(3);
             expect(batch.getChildAt(0)?.toArray()).toEqual(['NL', 'US', 'US']);
             expect(batch.getChildAt(1)?.toArray()).toEqual(['Amsterdam', 'Seattle', 'New York City']);
-            expect(batch.getChildAt(2)?.toArray()).toEqual([1005, 564, 8015]);
-            expect(batch.getChildAt(3)?.toArray()).toEqual([1065, 608, 8175]);
-            expect(batch.getChildAt(4)?.toArray()).toEqual([1158, 738, 8772]);
+            // Pivoted columns are int128
+            expect(batch.getChildAt(2)?.toArray()).toEqual(
+                new Uint32Array([1005, 0, 0, 0, 564, 0, 0, 0, 8015, 0, 0, 0]),
+            );
+            expect(batch.getChildAt(3)?.toArray()).toEqual(
+                new Uint32Array([1065, 0, 0, 0, 608, 0, 0, 0, 8175, 0, 0, 0]),
+            );
+            expect(batch.getChildAt(4)?.toArray()).toEqual(
+                new Uint32Array([1158, 0, 0, 0, 738, 0, 0, 0, 8772, 0, 0, 0]),
+            );
         });
     });
 }

--- a/packages/duckdb-wasm/test/pivot.test.ts
+++ b/packages/duckdb-wasm/test/pivot.test.ts
@@ -1,0 +1,44 @@
+import * as duckdb from '../src/';
+
+export function testPivot(db: () => duckdb.DuckDBBindings): void {
+    let conn: duckdb.DuckDBConnection;
+    beforeEach(() => {
+        conn = db().connect();
+    });
+
+    afterEach(() => {
+        conn.close();
+        db().flushFiles();
+        db().dropFiles();
+    });
+
+    describe('PIVOT', () => {
+        it('with send', async () => {
+            conn.query(`
+CREATE TABLE cities (
+  country VARCHAR, name VARCHAR, year INTEGER, population INTEGER
+);`);
+            conn.query(`
+INSERT INTO cities VALUES
+  ('NL', 'Amsterdam', 2000, 1005),
+  ('NL', 'Amsterdam', 2010, 1065),
+  ('NL', 'Amsterdam', 2020, 1158),
+  ('US', 'Seattle', 2000, 564),
+  ('US', 'Seattle', 2010, 608),
+  ('US', 'Seattle', 2020, 738),
+  ('US', 'New York City', 2000, 8015),
+  ('US', 'New York City', 2010, 8175),
+  ('US', 'New York City', 2020, 8772);`);
+
+            const reader = await conn.send(`PIVOT cities ON year USING sum(population);`);
+            const batches = reader.readAll();
+            expect(batches.length).toBe(1);
+            const batch = batches[0];
+            expect(batch.numCols).toBe(5);
+            expect(batch.numRows).toBe(3);
+            expect(batch.getChildAt(0)?.toArray()).toEqual(
+                '{"country":"NL","name":"Amsterdam","2000":1005,"2010":1065,"2020":1158}',
+            );
+        });
+    });
+}

--- a/packages/duckdb-wasm/test/pivot.test.ts
+++ b/packages/duckdb-wasm/test/pivot.test.ts
@@ -36,9 +36,11 @@ INSERT INTO cities VALUES
             const batch = batches[0];
             expect(batch.numCols).toBe(5);
             expect(batch.numRows).toBe(3);
-            expect(batch.getChildAt(0)?.toArray()).toEqual(
-                '{"country":"NL","name":"Amsterdam","2000":1005,"2010":1065,"2020":1158}',
-            );
+            expect(batch.getChildAt(0)?.toArray()).toEqual(['NL', 'US', 'US']);
+            expect(batch.getChildAt(1)?.toArray()).toEqual(['Amsterdam', 'Seattle', 'New York City']);
+            expect(batch.getChildAt(2)?.toArray()).toEqual([1005, 564, 8015]);
+            expect(batch.getChildAt(3)?.toArray()).toEqual([1065, 608, 8175]);
+            expect(batch.getChildAt(4)?.toArray()).toEqual([1158, 738, 8772]);
         });
     });
 }


### PR DESCRIPTION
PIVOT is transformed into multiple statements by the parser. Since PendingQuery doesn't support multiple statements, this causes PIVOT statements to fail when used with `send`.

This change fixes this by using ExtractStatements to transform the text passed to WebDB::Connection::PendingQuery into possibly multiple parsed statements. Each one is run in turn; results are returned for the last one.

I added a unit test for this case. I did have to skip some of the checks (of the aggregated values) on Node, because they were returned as different types depending on the build (loadable or not). They work fine in the browser.