### PR TITLE
example: Fix typo of `asynchronus`

### DIFF
--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -22,7 +22,7 @@
           })
         );
 
-        // Instantiate the asynchronus version of DuckDB-wasm
+        // Instantiate the asynchronous version of DuckDB-wasm
         const worker = new Worker(worker_url);
         // const logger = null //new duckdb.ConsoleLogger();
         const logger = new duckdb.ConsoleLogger();


### PR DESCRIPTION
Thanks for simple example.
Found a typo same as https://github.com/duckdb/duckdb-wasm/pull/1940

```
$ git grep asynchronus
examples/plain-html/index.html:        // Instantiate the asynchronus version of DuckDB-wasm
```