### PR TITLE
Add forceFullHTTPReads filesystem config flag.

### DIFF
--- a/lib/include/duckdb/web/config.h
+++ b/lib/include/duckdb/web/config.h
@@ -71,6 +71,8 @@ struct DuckDBConfigOptions {
 struct FileSystemConfig {
     /// Allow falling back to full HTTP reads if the server does not support range requests
     std::optional<bool> allow_full_http_reads = std::nullopt;
+    /// Force full HTTP reads, suppressing use of range requests
+    std::optional<bool> force_full_http_reads = std::nullopt;
     std::optional<bool> reliable_head_requests = std::nullopt;
 };
 
@@ -91,7 +93,11 @@ struct WebDBConfig {
         .cast_decimal_to_double = std::nullopt,
     };
     /// The filesystem
-    FileSystemConfig filesystem = {.allow_full_http_reads = std::nullopt, .reliable_head_requests = std::nullopt};
+    FileSystemConfig filesystem = {
+        .allow_full_http_reads = std::nullopt,
+        .force_full_http_reads = std::nullopt,
+        .reliable_head_requests = std::nullopt,
+    };
 
     /// These options are fetched from DuckDB
     DuckDBConfigOptions duckdb_config_options = {

--- a/lib/src/config.cc
+++ b/lib/src/config.cc
@@ -49,6 +49,7 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
                               .filesystem =
                                   FileSystemConfig{
                                       .allow_full_http_reads = std::nullopt,
+                                      .force_full_http_reads = std::nullopt,
                                       .reliable_head_requests = std::nullopt,
                                   },
                               .duckdb_config_options =
@@ -105,6 +106,9 @@ WebDBConfig WebDBConfig::ReadFrom(std::string_view args_json) {
             auto fs = doc["filesystem"].GetObject();
             if (fs.HasMember("allowFullHTTPReads") && fs["allowFullHTTPReads"].IsBool()) {
                 config.filesystem.allow_full_http_reads = fs["allowFullHTTPReads"].GetBool();
+            }
+            if (fs.HasMember("forceFullHTTPReads") && fs["forceFullHTTPReads"].IsBool()) {
+                config.filesystem.force_full_http_reads = fs["forceFullHTTPReads"].GetBool();
             }
             if (fs.HasMember("reliableHeadRequests") && fs["reliableHeadRequests"].IsBool()) {
                 config.filesystem.reliable_head_requests = fs["reliableHeadRequests"].GetBool();

--- a/lib/src/io/web_filesystem.cc
+++ b/lib/src/io/web_filesystem.cc
@@ -325,7 +325,10 @@ rapidjson::Value WebFileSystem::WebFile::WriteInfo(rapidjson::Document &doc) con
         filesystem_.config_->filesystem.allow_full_http_reads.value_or(true)) {
         value.AddMember("allowFullHttpReads", true, allocator);
     }
-
+    if ((data_protocol_ == DataProtocol::HTTP || data_protocol_ == DataProtocol::S3) &&
+        filesystem_.config_->filesystem.force_full_http_reads.value_or(true)) {
+        value.AddMember("forceFullHttpReads", true, allocator);
+    }
     if ((data_protocol_ == DataProtocol::HTTP || data_protocol_ == DataProtocol::S3)) {
         if (filesystem_.config_->duckdb_config_options.reliable_head_requests)
             value.AddMember("reliableHeadRequests", true, allocator);
@@ -517,6 +520,9 @@ rapidjson::Value WebFileSystem::WriteGlobalFileInfo(rapidjson::Document &doc, ui
 
     if (config_->filesystem.allow_full_http_reads.value_or(true)) {
         value.AddMember("allowFullHttpReads", true, allocator);
+    }
+    if (config_->filesystem.force_full_http_reads.value_or(true)) {
+        value.AddMember("forceFullHttpReads", true, allocator);
     }
     if (config_->filesystem.reliable_head_requests.value_or(true)) {
         value.AddMember("reliableHeadRequests", true, allocator);

--- a/packages/duckdb-wasm/src/bindings/config.ts
+++ b/packages/duckdb-wasm/src/bindings/config.ts
@@ -22,11 +22,15 @@ export interface DuckDBQueryConfig {
 }
 
 export interface DuckDBFilesystemConfig {
+    reliableHeadRequests?: boolean;
     /**
      * Allow falling back to full HTTP reads if the server does not support range requests.
      */
-    reliableHeadRequests?: boolean;
     allowFullHTTPReads?: boolean;
+    /**
+     * Force use of full HTTP reads, suppressing range requests.
+     */
+    forceFullHTTPReads?: boolean;
 }
 
 export enum DuckDBAccessMode {

--- a/packages/duckdb-wasm/src/bindings/runtime.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime.ts
@@ -83,6 +83,7 @@ export interface DuckDBFileInfo {
     dataUrl: string | null;
     reliableHeadRequests?: boolean;
     allowFullHttpReads?: boolean;
+    forceFullHttpReads?: boolean;
     s3Config?: S3Config;
 }
 
@@ -91,6 +92,7 @@ export interface DuckDBGlobalFileInfo {
     cacheEpoch: number;
     reliableHeadRequests?: boolean;
     allowFullHttpReads?: boolean;
+    forceFullHttpReads?: boolean;
     s3Config?: S3Config;
 }
 

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -244,7 +244,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                     // Supports ranges?
                     let contentLength = null;
                     let error: any | null = null;
-                    if (file.reliableHeadRequests || !file.allowFullHttpReads) {
+                    if (!file.forceFullHttpReads && (file.reliableHeadRequests || !file.allowFullHttpReads)) {
                         try {
                             // Send a dummy HEAD request with range protocol
                             //          -> good IFF status is 206 and contentLenght is present
@@ -278,7 +278,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
 
                     // Try to fallback to full read?
                     if (file.allowFullHttpReads) {
-                        {
+                        if (!file.forceFullHttpReads) {
                             // 2. Send a dummy GET range request querying the first byte of the file
                             //          -> good IFF status is 206 and contentLenght2 is 1
                             //          -> otherwise, iff 200 and contentLenght2 == contentLenght
@@ -354,8 +354,8 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                                 mod.HEAPF64[(result >> 3) + 2] = +modification_time;
                                 return result;
                             }
+                            console.warn(`falling back to full HTTP read for: ${file.dataUrl}`);
                         }
-                        console.warn(`falling back to full HTTP read for: ${file.dataUrl}`);
                         // 3. Send non-range request
                         const xhr = new XMLHttpRequest();
                         if (file.dataProtocol == DuckDBDataProtocol.S3) {


### PR DESCRIPTION
This PR adds a new filesystem configuration option: `forceFullHTTPReads`. If enabled, this flag suppresses the use of HTTP range requests for DuckDB-WASM is running in the browser.

The flag is set via the database `open` method:

```js
const worker = new Worker(config.mainWorker);
const db = new AsyncDuckDB(new ConsoleLogger(), worker);
await db.instantiate(config.mainModule, config.pthreadWorker);
await db.open({
  filesystem: {
    forceFullHTTPReads: true
  }
});
```

The flag passes in through WASM (C code), and back to a worker thread (TypeScript code) where the actual file loads are performed.

**Why add this flag?**

- Firefox has bad interactions with range requests and compression on some servers (including GitHub Pages), causing file loading in DuckDB-WASM to crash rather than gracefully fallback to full reads. Setting this flag sidesteps the error and enables successful file loading.
- When one knows ahead of time that the full data is needed, full file reads can be more efficient by making a single HTTP call rather than multiple.
- Full file reads result in fewer operations when connecting to object storage like R2 and S3, potentially reducing bills.