### PR TITLE
Add proper support for CAPI in duckdb-wasm

### DIFF
--- a/patches/duckdb/extension_install_rework.patch
+++ b/patches/duckdb/extension_install_rework.patch
@@ -134,10 +134,27 @@ index 2ea03b8e49..d8c710f153 100644
  	// Install is currently a no-op
  	return nullptr;
 diff --git a/src/main/extension/extension_load.cpp b/src/main/extension/extension_load.cpp
-index 6e4bb18796..188931a84d 100644
+index 6e4bb18796..f05c13ab59 100644
 --- a/src/main/extension/extension_load.cpp
 +++ b/src/main/extension/extension_load.cpp
-@@ -327,7 +327,20 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
+@@ -9,6 +9,8 @@
+ #include "duckdb/main/extension_helper.hpp"
+ #include "mbedtls_wrapper.hpp"
+ 
++
++#include <iostream>
+ #ifndef DUCKDB_NO_THREADS
+ #include <thread>
+ #endif // DUCKDB_NO_THREADS
+@@ -321,13 +323,29 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
+ 	auto filename = fs.ConvertSeparators(extension);
+ 
+ 	bool direct_load;
++	ParsedExtensionMetaData parsed_metadata;
++	ExtensionInstallMode install_mode = ExtensionInstallMode::UNKNOWN;
+ 
+ 	// shorthand case
+ 	if (!ExtensionHelper::IsFullPath(extension)) {
  		direct_load = false;
  		string extension_name = ApplyExtensionAlias(extension);
  #ifdef WASM_LOADABLE_EXTENSIONS
@@ -154,12 +171,13 @@ index 6e4bb18796..188931a84d 100644
 +                               repository = ExtensionRepository("x", preferredRepo);
 +                       }
 +               }
++		install_mode = ExtensionInstallMode::REPOSITORY;
 +
 +		string url_template = ExtensionUrlTemplate(db, repository, "");
  		string url = ExtensionFinalizeUrlTemplate(url_template, extension_name);
  
  		char *str = (char *)EM_ASM_PTR(
-@@ -368,35 +381,31 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
+@@ -368,35 +386,32 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
  		direct_load = true;
  		filename = fs.ExpandPath(filename);
  	}
@@ -189,17 +207,14 @@ index 6e4bb18796..188931a84d 100644
 -	// Parse the extension metadata from the extension binary
 -	auto parsed_metadata = ParseExtensionMetaData(*handle);
 +	    // Parse the extension metadata from the extension binary
-+	    auto parsed_metadata = ParseExtensionMetaData(*handle);
  
 -	auto metadata_mismatch_error = parsed_metadata.GetInvalidMetadataError();
-+	    auto metadata_mismatch_error = parsed_metadata.GetInvalidMetadataError();
++	    auto parsed_metadata = ParseExtensionMetaData(*handle);
  
 -	if (!metadata_mismatch_error.empty()) {
 -		metadata_mismatch_error = StringUtil::Format("Failed to load '%s', %s", extension, metadata_mismatch_error);
 -	}
-+	    if (!metadata_mismatch_error.empty()) {
-+	        metadata_mismatch_error = StringUtil::Format("Failed to load '%s', %s", extension, metadata_mismatch_error);
-+	    }
++	    auto metadata_mismatch_error = parsed_metadata.GetInvalidMetadataError();
  
 -	if (!db.config.options.allow_unsigned_extensions) {
 -		bool signature_valid;
@@ -209,13 +224,17 @@ index 6e4bb18796..188931a84d 100644
 -		} else {
 -			signature_valid = false;
 -		}
++	    if (!metadata_mismatch_error.empty()) {
++	        metadata_mismatch_error = StringUtil::Format("Failed to load '%s', %s", extension, metadata_mismatch_error);
++	    }
++
 +	    if (!db.config.options.allow_unsigned_extensions) {
 +	        bool signature_valid =
 +	            CheckExtensionSignature(*handle, parsed_metadata, db.config.options.allow_community_extensions);
  
  		if (!metadata_mismatch_error.empty()) {
  			throw InvalidInputException(metadata_mismatch_error);
-@@ -413,26 +422,192 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
+@@ -413,26 +428,203 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
  		}
  	}
  
@@ -412,18 +431,29 @@ index 6e4bb18796..188931a84d 100644
 +			throw IOException(db.config.error_manager->FormatException(ErrorType::UNSIGNED_EXTENSION, filename));
 +		}
 +	}
++
 +	if (exe) {
++		uint64_t LEN = 0;
++		LEN *= 256;
++		LEN += ((uint8_t *)exe)[3];
++		LEN *= 256;
++		LEN += ((uint8_t *)exe)[2];
++		LEN *= 256;
++		LEN += ((uint8_t *)exe)[1];
++		LEN *= 256;
++		LEN += ((uint8_t *)exe)[0];
++		parsed_metadata = ParseExtensionMetaData(exe + LEN + 4 - ParsedExtensionMetaData::FOOTER_SIZE);
 +		free(exe);
 +	}
  #else
  	auto dopen_from = filename;
  #endif
-@@ -448,28 +623,30 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
- 	result.filebase = lowercase_extension_name;
+@@ -449,27 +641,30 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
  	result.filename = filename;
  	result.lib_hdl = lib_hdl;
--	result.abi_type = parsed_metadata.abi_type;
-+	result.abi_type = ExtensionABIType::CPP;
+ 	result.abi_type = parsed_metadata.abi_type;
++	result.install_info->version = parsed_metadata.extension_version;
++	result.install_info->mode = install_mode;
  
  	if (!direct_load) {
 -		auto info_file_name = filename + ".info";
@@ -461,7 +491,15 @@ index 6e4bb18796..188931a84d 100644
  		result.install_info->mode = ExtensionInstallMode::NOT_INSTALLED;
  		result.install_info->full_path = filename;
 -		result.install_info->version = parsed_metadata.extension_version;
-+		result.install_info->version = ""; // parsed_metadata.extension_version;
  	}
  
  	return true;
+@@ -589,7 +784,7 @@ void ExtensionHelper::LoadExternalExtension(DatabaseInstance &db, FileSystem &fs
+ 		return;
+ 	}
+ 
+-	throw IOException("Unknown ABI type of value '%s' for extension '%s'",
++	throw IOException("Unknown ABI type of value '%d' for extension '%s'",
+ 	                  static_cast<uint8_t>(extension_init_result.abi_type), extension);
+ #endif
+ }


### PR DESCRIPTION
After this lands:
```sql
INSTALL arrow FROM community;
LOAD arrow;
```
works as indented

AND versions of installed extensions are shown.