### PR TITLE
Fix send('SELECT ...') infinite loop on detached state (no worker defined)

### DIFF
--- a/packages/duckdb-wasm/src/parallel/async_bindings.ts
+++ b/packages/duckdb-wasm/src/parallel/async_bindings.ts
@@ -310,6 +310,11 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
         this._pendingRequests.clear();
     }
 
+    /** Is in detached state, no worker defined */
+    public isDetached(): boolean {
+        return !this._worker;
+    }
+
     /** Reset the duckdb */
     public async reset(): Promise<null> {
         const task = new WorkerTask<WorkerRequestType.RESET, null, null>(WorkerRequestType.RESET, null);

--- a/packages/duckdb-wasm/src/parallel/async_connection.ts
+++ b/packages/duckdb-wasm/src/parallel/async_connection.ts
@@ -62,6 +62,11 @@ export class AsyncDuckDBConnection {
         });
         let header = await this._bindings.startPendingQuery(this._conn, text, allowStreamResult);
         while (header == null) {
+            // Avoid infinite loop on detached state
+            if (this._bindings.isDetached()) {
+                console.error('cannot send a message since the worker is not set!');
+                return undefined as any;
+            }
             header = await this._bindings.pollPendingQuery(this._conn);
         }
         const iter = new AsyncResultStreamIterator(this._bindings, this._conn, header);


### PR DESCRIPTION
This PR will prevent infinite loop in `connection.send('SELECT ...')` function, when _bindings is in detached mode (no worker associated)

There is a while loop waiting header variable to be defined. However,`this._bindings.pollPendingQuery(this._conn)` will just emit a console.error and return undefined, which will cause infinite loop.  

@carlopi if you have any improvement suggestion feel free.

Related issue: https://github.com/duckdb/duckdb-wasm/issues/1970