### PR TITLE
Initialize HTTPParams, in turn ininitializing logger

### DIFF
--- a/lib/include/duckdb/web/http_wasm.h
+++ b/lib/include/duckdb/web/http_wasm.h
@@ -33,7 +33,9 @@ class HTTPWasmUtil : public HTTPUtil {
    public:
     unique_ptr<HTTPParams> InitializeParameters(optional_ptr<FileOpener> opener,
                                                 optional_ptr<FileOpenerInfo> info) override {
-        return make_uniq<HTTPFSParams>(*this);
+        auto result = make_uniq<HTTPFSParams>(*this);
+        result->Initialize(opener);
+        return result;
     }
     unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-wasm/issues/2091

After this:
```sql
SET builtin_httpfs = false; ---this needs to be removed / turn as default
CALL enable_logging('HTTP');
LOAD httpfs;
CREATE TABLE T AS (SELECT * FROM read_json('https://dummyjson.com/products/1'));
SELECT request.type FROM duckdb_logs_parsed('HTTP');
```
should return:
```
HEAD
GET
HEAD
```