### PR TITLE
opfs: enable opfs temp_directory via pre-registered pool

### DIFF
--- a/packages/duckdb-wasm/src/bindings/bindings_base.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_base.ts
@@ -13,6 +13,7 @@ import { arrowToSQLField, arrowToSQLType } from '../json_typedef';
 import { WebFile } from './web_file';
 import { UDFFunction, UDFFunctionDeclaration } from './udf_function';
 import * as arrow from 'apache-arrow';
+import { createOPFSTempPool } from '../utils/opfs_util';
 
 const TEXT_ENCODER = new TextEncoder();
 
@@ -701,6 +702,21 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
             throw new Error('Not an OPFS file name: ' + file);
         }
     }
+
+    public async registerOPFSTempDir(tempPath?: string, maxPoolSize?: number, minPoolSize?: number): Promise<void> {
+        // Access BROWSER_RUNTIME through the runtime field
+        const runtime = this._runtime as any;
+
+        if (runtime._opfsTmpPool) {
+            await runtime._opfsTmpPool.destroy();
+            runtime._opfsTmpPool = null;
+        }
+
+        if (tempPath) {
+            runtime._opfsTmpPool = await createOPFSTempPool(tempPath, { maxUnused: maxPoolSize, minUnused: minPoolSize });
+        }
+    }
+
     public collectFileStatistics(file: string, enable: boolean): void {
         const [s, d, n] = callSRet(this.mod, 'duckdb_web_collect_file_stats', ['string', 'boolean'], [file, enable]);
         if (s !== StatusCode.SUCCESS) {

--- a/packages/duckdb-wasm/src/bindings/bindings_interface.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_interface.ts
@@ -63,6 +63,7 @@ export interface DuckDBBindings {
     copyFileToPath(name: string, path: string): void;
     copyFileToBuffer(name: string): Uint8Array;
     registerOPFSFileName(file: string): Promise<void>;
+    registerOPFSTempDir(tempPath?: string, maxPoolSize?: number, minPoolSize?: number): Promise<void>;
     collectFileStatistics(file: string, enable: boolean): void;
     exportFileStatistics(file: string): FileStatistics;
 }

--- a/packages/duckdb-wasm/src/bindings/config.ts
+++ b/packages/duckdb-wasm/src/bindings/config.ts
@@ -40,6 +40,37 @@ export interface DuckDBOPFSConfig {
      * - "manual": Files must be manually registered and dropped.
      */
     fileHandling?: "auto" | "manual";
+
+    /**
+     * OPFS path for temporary files (e.g., "opfs://tmp").
+     *
+     * When set, a "pool" of pre-allocated temp files is maintained for use by
+     * DuckDB when it opens a tempfile on-demand. Pre-allocation of tempfiles is
+     * required when using OPFS due to the OPFS API providing only asynchronous
+     * file creation, while DuckDB's temp file creation must be synchronous. By
+     * maintaining a pool of pre-created temp files, DuckDB can synchronously
+     * claim a temp file from the pool when needed.
+     *
+     * `SET temp_directory='opfs://...` can also be used to initialize or change
+     * the temp directory at runtime when using "auto" fileHandling.
+     */
+    tempPath?: string;
+
+    /**
+     * Maximum number of pre-allocated file handles in the temp pool beyond
+     * returned files will be deleted when closed.
+     */
+    tempPoolMax?: number;
+
+    /**
+     * Minimum number of unused pre-allocated handles to maintain in any temp
+     * file pools. When a tempfile is opened from the pool causing the remaining
+     * unused handles to drop below this number, new handles will be created
+     * asynchronously in the background to refill the pool up to tempPoolMax.
+     *
+     * Must be less than tempPoolMax.
+     */
+    tempPoolMin?: number;
 }
 
 export enum DuckDBAccessMode {

--- a/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
@@ -365,7 +365,10 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
                     await this._bindings.registerOPFSFileName(request.data[0]);
                     this.sendOK(request);
                     break;
-
+                case WorkerRequestType.REGISTER_OPFS_TEMP_DIR:
+                    await this._bindings.registerOPFSTempDir(request.data[0], request.data[1], request.data[2]);
+                    this.sendOK(request);
+                    break;
                 case WorkerRequestType.EXPORT_FILE_STATISTICS: {
                     this.postMessage(
                         {

--- a/packages/duckdb-wasm/src/parallel/worker_request.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_request.ts
@@ -15,6 +15,7 @@ export enum WorkerRequestType {
     CLOSE_PREPARED = 'CLOSE_PREPARED',
     COLLECT_FILE_STATISTICS = 'COLLECT_FILE_STATISTICS',
     REGISTER_OPFS_FILE_NAME = 'REGISTER_OPFS_FILE_NAME',
+    REGISTER_OPFS_TEMP_DIR = 'REGISTER_OPFS_TEMP_DIR',
     CONNECT = 'CONNECT',
     COPY_FILE_TO_BUFFER = 'COPY_FILE_TO_BUFFER',
     COPY_FILE_TO_PATH = 'COPY_FILE_TO_PATH',
@@ -111,6 +112,7 @@ export type WorkerRequestVariant =
     | WorkerRequest<WorkerRequestType.CANCEL_PENDING_QUERY, number>
     | WorkerRequest<WorkerRequestType.COLLECT_FILE_STATISTICS, [string, boolean]>
     | WorkerRequest<WorkerRequestType.REGISTER_OPFS_FILE_NAME, [string]>
+    | WorkerRequest<WorkerRequestType.REGISTER_OPFS_TEMP_DIR, [string?, number?, number?]>
     | WorkerRequest<WorkerRequestType.CONNECT, null>
     | WorkerRequest<WorkerRequestType.COPY_FILE_TO_BUFFER, string>
     | WorkerRequest<WorkerRequestType.COPY_FILE_TO_PATH, [string, string]>
@@ -171,6 +173,7 @@ export type WorkerResponseVariant =
 export type WorkerTaskVariant =
     | WorkerTask<WorkerRequestType.COLLECT_FILE_STATISTICS, [string, boolean], null>
     | WorkerTask<WorkerRequestType.REGISTER_OPFS_FILE_NAME, [string], null>
+    | WorkerTask<WorkerRequestType.REGISTER_OPFS_TEMP_DIR, [string?, number?, number?], null>
     | WorkerTask<WorkerRequestType.CLOSE_PREPARED, [number, number], null>
     | WorkerTask<WorkerRequestType.CONNECT, null, ConnectionID>
     | WorkerTask<WorkerRequestType.COPY_FILE_TO_BUFFER, string, Uint8Array>

--- a/packages/duckdb-wasm/src/utils/opfs_util.ts
+++ b/packages/duckdb-wasm/src/utils/opfs_util.ts
@@ -8,3 +8,125 @@ export function isOPFSProtocol(path: string): boolean {
 export function searchOPFSFiles(text: string) {
     return [...text.matchAll(REGEX_OPFS_FILE)].map(match => match[1]);
 }
+
+type HandleEntry = { name: string; handle: FileSystemSyncAccessHandle };
+
+export type TmpPoolConfig = { maxUnused?: number; minUnused?: number };
+
+/**
+ * TmpPool manages pre-allocated OPFS file handles for temporary files.
+ *
+ * DuckDB's file operations (openFile, dropFile, etc.) are synchronous C++ calls
+ * that cannot be made async. However, OPFS file creation requires async APIs.
+ * When DuckDB needs to create temporary files for spilling data to disk, it
+ * calls openFile synchronously, expecting an immediate file handle.
+ *
+ * To work around this API mismatch, we pre-create a pool of OPFS files with
+ * their sync access handles during the async temp directory registration. When
+ * DuckDB needs a temp file, we can synchronously hand out one of these
+ * pre-created handles from the pool. When the file is closed, we clear it and
+ * return it to the pool for reuse.
+ */
+export class TmpPool {
+  public readonly path: string;
+  private dir: FileSystemDirectoryHandle;
+  private maxUnused: number;
+  private minUnused: number;
+  private pool: HandleEntry[] = []; // unused files.
+  private openMap = new Map<string, HandleEntry>(); // checked out files.
+  private nextId = 1;
+  private refillInFlight = false;
+
+  constructor(
+    path: string,
+    dir: FileSystemDirectoryHandle,
+    maxUnused: number = 4,
+    minUnused: number = 2
+  ) {
+    if (minUnused >= maxUnused) throw new Error("minUnused must be < maxUnused");
+    this.path = canonicalDirUrl(path);
+    this.dir = dir;
+    this.maxUnused = maxUnused;
+    this.minUnused = minUnused;
+  }
+
+  async init(): Promise<void> { await this.refillTo(this.maxUnused); }
+
+  matches(path: string): boolean {
+    const canonical = canonicalDirUrl(path);
+    return canonical === this.path || canonical.startsWith(this.path);
+  }
+
+  openFile(path: string): FileSystemSyncAccessHandle {
+    const existing = this.openMap.get(path); if (existing) return existing.handle;
+    if (this.pool.length === 0) throw new Error("OPFS tmp pool exhausted");
+    const entry = this.pool.pop()!; this.openMap.set(path, entry);
+    if (this.pool.length < this.minUnused) this.maybeRefillAsync();
+    return entry.handle;
+  }
+
+  dropFile(path: string): void {
+    const entry = this.openMap.get(path); if (!entry) return;
+    entry.handle.flush();
+
+    if (this.pool.length >= this.maxUnused) {
+      this.asyncDelete(entry).catch(() => {});
+    } else {
+      entry.handle.truncate(0);
+      this.pool.push(entry);
+    }
+    this.openMap.delete(path);
+  }
+
+  async destroy(): Promise<void> {
+    await Promise.all(this.pool.splice(0).map(e => this.asyncDelete(e)));
+  }
+
+  private async createEntry(): Promise<HandleEntry> {
+    const name = `tmp${this.nextId++}`;
+    const fh = await this.dir.getFileHandle(name, { create: true });
+    const sah = await fh.createSyncAccessHandle();
+    sah.truncate(0);
+    return { name, handle: sah };
+  }
+  private async refillTo(target: number): Promise<void> {
+    while (this.pool.length < target) {
+      const e = await this.createEntry(); this.pool.push(e);
+    }
+  }
+  private maybeRefillAsync() {
+    if (this.refillInFlight) return;
+    this.refillInFlight = true;
+    this.refillTo(this.maxUnused).finally(() => { this.refillInFlight = false; });
+  }
+  private async asyncDelete(e: HandleEntry) {
+    try { e.handle.flush(); } catch { /* ignore errors */ }
+    try { e.handle.close(); } catch { /* ignore errors */ }
+    try { await this.dir.removeEntry(e.name); } catch { /* ignore errors */ }
+  }
+}
+
+export function canonicalDirUrl(url: string) {
+  return url.replace(/\/+$/, "");
+}
+
+export async function resolveOpfsDirectory(opfsUrl: string): Promise<FileSystemDirectoryHandle> {
+  const root = await (navigator as any).storage.getDirectory();
+  const rel = opfsUrl.slice("opfs://".length).replace(/^\/+/, "");
+  const parts = rel.split("/").filter(Boolean);
+  let dir: FileSystemDirectoryHandle = root;
+  for (const p of parts) {
+    dir = await dir.getDirectoryHandle(p, { create: true });
+  }
+  return dir;
+}
+
+export async function createOPFSTempPool(opfsDirUrl: string, cfg: TmpPoolConfig = {}) : Promise<TmpPool> {
+  const key = canonicalDirUrl(opfsDirUrl);
+  const dir = await resolveOpfsDirectory(key);
+  const maxUnused = cfg.maxUnused ?? 10;
+  const minUnused = cfg.minUnused ?? 2;
+  const pool = new TmpPool(key, dir, maxUnused, minUnused);
+  await pool.init();
+  return pool;
+}


### PR DESCRIPTION
Previously attempting to set temp_directory to an `opfs://` path did not work. 

Specifically, while 'auto' file handling scanned SQL stmts for `opfs://` paths to pre-open mentioned files via the async OPFS API and register them where the sync openFile call could find them, it only worked for specific *files* and not for a temp *directory*, i.e. a path _in which_ `openFile` would later attempt to create individual files.

The sync vs async APIs of openFile vs OPFS presents a challenge here: when the DB decides to spill to a tempfile and attempts to create it, it does so via the `openFile` call, which is a sync call. This makes creating the OPFS file at that point, via the async OPFS API, a problem.

To get around this, as of this change, when an OPFS temp directory is registered, it sets up a 'pool' of pre-created empty temp files, with sync access handles to each pre-created, which can then be handed out as needed to (sync) `openFile` calls. When closed, a file can be truncated and returned to the pool, or be deleted if the pool is full. When the pool runs low on pre-created files, new files can be opened -- async -- and added to it.

This somewhat indirect approach works around the sync vs async API mismatch, while still allowing openFile calls to create arbitrarily named -- from its point of view -- files at arbitrary times. The included tests show this in action for opfs temp directories, both when configured via `SET` at interactively and via up-front configuration passed to `open()`.

Fixes #2061.