### PR TITLE
fix: add cache invalidation for re-registered files

### DIFF
--- a/lib/src/io/web_filesystem.cc
+++ b/lib/src/io/web_filesystem.cc
@@ -1,5 +1,6 @@
 #include "duckdb/web/io/web_filesystem.h"
 
+#include <chrono>
 #include <cstdint>
 #include <iostream>
 #include <mutex>
@@ -410,6 +411,11 @@ arrow::Result<std::unique_ptr<WebFileSystem::WebFileHandle>> WebFileSystem::Regi
 arrow::Result<std::unique_ptr<WebFileSystem::WebFileHandle>> WebFileSystem::RegisterFileBuffer(
     std::string_view file_name, DataBuffer file_buffer) {
     DEBUG_TRACE();
+
+    // Get current time for cache invalidation
+    auto now = std::chrono::system_clock::now();
+    auto now_seconds = std::chrono::duration<double>(now.time_since_epoch()).count();
+
     // Check if the file exists
     std::unique_lock<LightMutex> fs_guard{fs_mutex_};
     auto iter = files_by_name_.find(std::string{file_name});
@@ -422,7 +428,7 @@ arrow::Result<std::unique_ptr<WebFileSystem::WebFileHandle>> WebFileSystem::Regi
             case DataProtocol::BROWSER_FSACCESS:
             case DataProtocol::BROWSER_FILEREADER: {
                 file->file_size_ = file_buffer.Size();
-                file->last_modification_time_ = std::nullopt;
+                file->last_modification_time_ = now_seconds;
                 file->data_buffer_ = std::move(file_buffer);
                 auto handle = std::make_unique<WebFileHandle>(file);
                 fs_guard.unlock();
@@ -436,7 +442,7 @@ arrow::Result<std::unique_ptr<WebFileSystem::WebFileHandle>> WebFileSystem::Regi
             case DataProtocol::BUFFER:
                 file->data_protocol_ = DataProtocol::BUFFER;
                 file->file_size_ = file_buffer.Size();
-                file->last_modification_time_ = std::nullopt;
+                file->last_modification_time_ = now_seconds;
                 file->data_buffer_ = std::move(file_buffer);
                 return std::make_unique<WebFileHandle>(file);
         }
@@ -446,7 +452,7 @@ arrow::Result<std::unique_ptr<WebFileSystem::WebFileHandle>> WebFileSystem::Regi
     auto file_id = AllocateFileID();
     auto file = std::make_shared<WebFile>(*this, file_id, file_name, DataProtocol::BUFFER);
     file->file_size_ = file_buffer.Size();
-    file->last_modification_time_ = std::nullopt;
+    file->last_modification_time_ = now_seconds;
     file->data_buffer_ = std::move(file_buffer);
 
     // Register the file
@@ -924,7 +930,8 @@ timestamp_t WebFileSystem::GetLastModifiedTime(duckdb::FileHandle &handle) {
     // Get the file handle
     auto &file_hdl = static_cast<WebFileHandle &>(handle);
     assert(file_hdl.file_);
-    return timestamp_t(file_hdl.file_->last_modification_time_.value_or(0) * 1000);
+    // Convert seconds to microseconds (timestamp_t expects microseconds)
+    return timestamp_t(static_cast<int64_t>(file_hdl.file_->last_modification_time_.value_or(0) * 1000000));
 }
 /// Truncate a file to a maximum size of new_size, new_size should be smaller than or equal to the current size of
 /// the file

--- a/packages/duckdb-wasm/test/regression/github_2076.test.ts
+++ b/packages/duckdb-wasm/test/regression/github_2076.test.ts
@@ -1,0 +1,49 @@
+import * as duckdb from '../../src';
+
+// https://github.com/duckdb/duckdb-wasm/issues/2076
+export function test2076(db: () => duckdb.AsyncDuckDB): void {
+    let conn: duckdb.AsyncDuckDBConnection;
+    beforeEach(async () => {
+        await db().flushFiles();
+        conn = await db().connect();
+    });
+    afterEach(async () => {
+        await conn.close();
+        await db().flushFiles();
+        await db().dropFiles();
+    });
+    describe('GitHub issues', () => {
+        it('2076', async () => {
+            // Generate first parquet file with 2 columns
+            await conn.query(`CREATE TABLE t1 AS SELECT 1 as id, 'first' as name`);
+            await conn.query(`COPY t1 TO 'test.parquet' (FORMAT PARQUET)`);
+            const parquet1 = await db().copyFileToBuffer('test.parquet');
+            await db().dropFile('test.parquet');
+            await conn.query(`DROP TABLE t1`);
+
+            // Generate second parquet file with different content (3 columns)
+            await conn.query(`CREATE TABLE t2 AS SELECT 100 as value, 200 as other, 300 as third`);
+            await conn.query(`COPY t2 TO 'test2.parquet' (FORMAT PARQUET)`);
+            const parquet2 = await db().copyFileToBuffer('test2.parquet');
+            await db().dropFile('test2.parquet');
+            await conn.query(`DROP TABLE t2`);
+
+            // Register first parquet at path 'data.parquet'
+            await db().registerFileBuffer('data.parquet', parquet1);
+            const result1 = await conn.query(`SELECT * FROM parquet_scan('data.parquet')`);
+            expect(result1.numRows).toEqual(1);
+            expect(result1.schema.fields.length).toEqual(2);
+
+            // Drop the file
+            await db().dropFile('data.parquet');
+
+            // Step 3: Register second parquet at SAME path
+            await db().registerFileBuffer('data.parquet', parquet2);
+
+            // Query should return data from second file
+            const result2 = await conn.query(`SELECT * FROM parquet_scan('data.parquet')`);
+            expect(result2.numRows).toEqual(1);
+            expect(result2.schema.fields.length).toEqual(3);
+        });
+    });
+}

--- a/packages/duckdb-wasm/test/regression/index.ts
+++ b/packages/duckdb-wasm/test/regression/index.ts
@@ -7,6 +7,7 @@ import { test470 } from './github_470.test';
 import { test477 } from './github_477.test';
 import { test1467 } from './github_1467.test';
 import { test1833 } from './github_1833.test';
+import { test2076 } from './github_2076.test';
 
 export function testRegressionAsync(adb: () => duckdb.AsyncDuckDB): void {
     test332(adb);
@@ -17,4 +18,5 @@ export function testRegressionAsync(adb: () => duckdb.AsyncDuckDB): void {
     test477(adb);
     test1467(adb);
     test1833(adb);
+    test2076(adb);
 }


### PR DESCRIPTION
When different file are registered using the same name, the previous file wasn't cleaned correctly
When a file is registered, last_modification_time_ was set to std::nullopt but it seems important to set a time to allow file to reset correctly

- Add modification timestamps in web_filesystem.cc for cache validation
- Add regression tests for Parquet file re-registration

@carlopi Feel free to update this PR 

Related to #2076

Refer to this commit
https://github.com/duckdb/duckdb-wasm/pull/2058/commits/227745bf521e346ad21e7c52242c378063ae759a