### PR TITLE
Revamp HTTPWasmClient: Now with support for HTTP_EXTRA_HEADERS

### DIFF
--- a/lib/include/duckdb/web/http_wasm.h
+++ b/lib/include/duckdb/web/http_wasm.h
@@ -1,4 +1,6 @@
+#include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/http_util.hpp"
+#include "duckdb/main/secret/secret.hpp"
 
 namespace duckdb {
 
@@ -23,11 +25,25 @@ struct HTTPFSParams : public HTTPParams {
     string ca_cert_file;
     string bearer_token;
     bool unsafe_disable_etag_checks{false};
+    bool s3_version_id_pinning{false};
     shared_ptr<HTTPState> state;
     string user_agent = {""};
+    bool pre_merged_headers = false;
+    idx_t force_download_threshold = 0;
+
     // Additional fields needs to be appended at the end and need to be propagated from duckdb-httpfs
     // TODO: make this unnecessary
 };
+
+static string TryGetPrefix(const string &url) {
+    const string prefixes[] = {"s3://", "s3a://", "s3n://", "gcs://", "gs://", "r2://"};
+    for (auto &prefix : prefixes) {
+        if (StringUtil::StartsWith(StringUtil::Lower(url), prefix)) {
+            return prefix;
+        }
+    }
+    return {};
+}
 
 class HTTPWasmUtil : public HTTPUtil {
    public:
@@ -35,7 +51,81 @@ class HTTPWasmUtil : public HTTPUtil {
                                                 optional_ptr<FileOpenerInfo> info) override {
         auto result = make_uniq<HTTPFSParams>(*this);
         result->Initialize(opener);
-        return result;
+        // result->state = HTTPState::TryGetState(opener);
+
+        // No point in continuing without an opener
+        if (!opener) {
+            return std::move(result);
+        }
+
+        Value value;
+
+        // Setting lookups
+        FileOpener::TryGetCurrentSetting(opener, "http_timeout", result->timeout, info);
+        FileOpener::TryGetCurrentSetting(opener, "force_download", result->force_download, info);
+        FileOpener::TryGetCurrentSetting(opener, "force_download_threshold", result->force_download_threshold, info);
+        FileOpener::TryGetCurrentSetting(opener, "auto_fallback_to_full_download",
+                                         result->auto_fallback_to_full_download, info);
+        FileOpener::TryGetCurrentSetting(opener, "http_retries", result->retries, info);
+        FileOpener::TryGetCurrentSetting(opener, "http_retry_wait_ms", result->retry_wait_ms, info);
+        FileOpener::TryGetCurrentSetting(opener, "http_retry_backoff", result->retry_backoff, info);
+        FileOpener::TryGetCurrentSetting(opener, "http_keep_alive", result->keep_alive, info);
+        FileOpener::TryGetCurrentSetting(opener, "enable_curl_server_cert_verification",
+                                         result->enable_curl_server_cert_verification, info);
+        FileOpener::TryGetCurrentSetting(opener, "enable_server_cert_verification",
+                                         result->enable_server_cert_verification, info);
+        FileOpener::TryGetCurrentSetting(opener, "ca_cert_file", result->ca_cert_file, info);
+        FileOpener::TryGetCurrentSetting(opener, "hf_max_per_page", result->hf_max_per_page, info);
+        FileOpener::TryGetCurrentSetting(opener, "unsafe_disable_etag_checks", result->unsafe_disable_etag_checks,
+                                         info);
+        FileOpener::TryGetCurrentSetting(opener, "s3_version_id_pinning", result->s3_version_id_pinning, info);
+
+        unique_ptr<KeyValueSecretReader> settings_reader;
+
+        if (info && !TryGetPrefix(info->file_path).empty()) {
+            // This is an S3-type url, we should
+            const char *s3_secret_types[] = {"s3", "r2", "gcs", "aws", "http"};
+
+            idx_t secret_type_count = 5;
+            Value merge_http_secret_into_s3_request;
+            FileOpener::TryGetCurrentSetting(opener, "merge_http_secret_into_s3_request",
+                                             merge_http_secret_into_s3_request);
+
+            if (!merge_http_secret_into_s3_request.IsNull() && !merge_http_secret_into_s3_request.GetValue<bool>()) {
+                // Drop the http secret from the lookup
+                secret_type_count = 4;
+            }
+            settings_reader = make_uniq<KeyValueSecretReader>(*opener, info, s3_secret_types, secret_type_count);
+        } else {
+            settings_reader = make_uniq<KeyValueSecretReader>(*opener, info, "http");
+        }
+
+        // HTTP Secret lookups
+
+        string proxy_setting;
+        if (settings_reader->TryGetSecretKey<string>("http_proxy", proxy_setting) && !proxy_setting.empty()) {
+            idx_t port;
+            string host;
+            HTTPUtil::ParseHTTPProxyHost(proxy_setting, host, port);
+            result->http_proxy = host;
+            result->http_proxy_port = port;
+        }
+        result->override_verify_ssl = settings_reader->TryGetSecretKey<bool>("verify_ssl", result->verify_ssl);
+        settings_reader->TryGetSecretKey<string>("http_proxy_username", result->http_proxy_username);
+        settings_reader->TryGetSecretKey<string>("http_proxy_password", result->http_proxy_password);
+        settings_reader->TryGetSecretKey<string>("bearer_token", result->bearer_token);
+
+        Value extra_headers;
+        if (settings_reader->TryGetSecretKey("extra_http_headers", extra_headers)) {
+            auto children = MapValue::GetChildren(extra_headers);
+            for (const auto &child : children) {
+                auto kv = StructValue::GetChildren(child);
+                D_ASSERT(kv.size() == 2);
+                result->extra_headers[kv[0].GetValue<string>()] = kv[1].GetValue<string>();
+            }
+        }
+
+        return std::move(result);
     }
     unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;
 

--- a/lib/src/http_wasm.cc
+++ b/lib/src/http_wasm.cc
@@ -12,6 +12,20 @@ class HTTPLogger;
 class FileOpener;
 struct FileOpenerInfo;
 class HTTPState;
+HTTPHeaders TransformHeadersWasm(const HTTPHeaders &header_map, const HTTPParams &params) {
+    auto &httpfs_params = params.Cast<HTTPFSParams>();
+
+    HTTPHeaders res_headers;
+    for (auto &header : header_map) {
+        res_headers.Insert(header.first, header.second);
+    }
+    if (!httpfs_params.pre_merged_headers) {
+        for (auto &entry : params.extra_headers) {
+            res_headers.Insert(entry.first, entry.second);
+        }
+    }
+    return res_headers;
+}
 
 class HTTPWasmClient : public HTTPClient {
    public:
@@ -38,16 +52,16 @@ class HTTPWasmClient : public HTTPClient {
         if ((path.rfind("https://", 0) != 0) && (path.rfind("http://", 0) != 0)) {
             path = "https://" + path;
         }
+        auto headers = TransformHeadersWasm(info.headers, info.params);
 
         int n = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             n++;
         }
-
         char **z = (char **)(void *)malloc(n * 4 * 2);
 
         int i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             z[i] = (char *)malloc(h.first.size() * 4 + 1);
             memset(z[i], 0, h.first.size() * 4 + 1);
             memcpy(z[i], h.first.c_str(), h.first.size());
@@ -130,7 +144,7 @@ class HTTPWasmClient : public HTTPClient {
         // clang-format on
 
         i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             free(z[i]);
             i++;
             free(z[i]);
@@ -182,15 +196,16 @@ class HTTPWasmClient : public HTTPClient {
         if ((path.rfind("https://", 0) != 0) && (path.rfind("http://", 0) != 0)) {
             path = "https://" + path;
         }
+        auto headers = TransformHeadersWasm(info.headers, info.params);
         int n = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             n++;
         }
 
         char **z = (char **)(void *)malloc(n * 4 * 2);
 
         int i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             z[i] = (char *)malloc(h.first.size() * 4 + 1);
             memset(z[i], 0, h.first.size() * 4 + 1);
             memcpy(z[i], h.first.c_str(), h.first.size());
@@ -222,6 +237,7 @@ class HTTPWasmClient : public HTTPClient {
                     var ptr1 = HEAP32[($2)/4 + i ];
                     var ptr2 = HEAP32[($2)/4 + i + 1];
 
+console.log('HEAD', UTF8ToString(ptr1), UTF8ToString(ptr2));
                     try {
 			var z = encodeURI(UTF8ToString(ptr1));
 			if (z === "Host") z = "X-Host-Override";
@@ -313,7 +329,8 @@ class HTTPWasmClient : public HTTPClient {
             path.c_str(), n, z, "HEAD");
 
         i = 0;
-        for (auto h : info.headers) {
+
+        for (auto h : headers) {
             free(z[i]);
             i++;
             free(z[i]);
@@ -423,16 +440,16 @@ res->headers.Insert(head, tail);
         if ((path.rfind("https://", 0) != 0) && (path.rfind("http://", 0) != 0)) {
             path = "https://" + path;
         }
-
+        auto headers = TransformHeadersWasm(info.headers, info.params);
         int n = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             n++;
         }
 
         char **z = (char **)(void *)malloc(n * 4 * 2);
 
         int i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             z[i] = (char *)malloc(h.first.size() * 4 + 1);
             memset(z[i], 0, h.first.size() * 4 + 1);
             memcpy(z[i], h.first.c_str(), h.first.size());
@@ -529,7 +546,7 @@ res->headers.Insert(head, tail);
         free(payload);
 
         i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             free(z[i]);
             i++;
             free(z[i]);
@@ -579,15 +596,16 @@ res->headers.Insert(head, tail);
             path = "https://" + path;
         }
 
+        auto headers = TransformHeadersWasm(info.headers, info.params);
         int n = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             n++;
         }
 
         char **z = (char **)(void *)malloc(n * 4 * 2);
 
         int i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             z[i] = (char *)malloc(h.first.size() * 4 + 1);
             memset(z[i], 0, h.first.size() * 4 + 1);
             memcpy(z[i], h.first.c_str(), h.first.size());
@@ -684,7 +702,7 @@ res->headers.Insert(head, tail);
         free(payload);
 
         i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             free(z[i]);
             i++;
             free(z[i]);
@@ -734,15 +752,16 @@ res->headers.Insert(head, tail);
             path = "https://" + path;
         }
 
+        auto headers = TransformHeadersWasm(info.headers, info.params);
         int n = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             n++;
         }
 
         char **z = (char **)(void *)malloc(n * 4 * 2);
 
         int i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             z[i] = (char *)malloc(h.first.size() * 4 + 1);
             memset(z[i], 0, h.first.size() * 4 + 1);
             memcpy(z[i], h.first.c_str(), h.first.size());
@@ -826,7 +845,7 @@ res->headers.Insert(head, tail);
         // clang-format on
 
         i = 0;
-        for (auto h : info.headers) {
+        for (auto h : headers) {
             free(z[i]);
             i++;
             free(z[i]);


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-wasm/issues/2110

This adds proper support for cases where one wants to add extra headers via:
```sql
CREATE SECRET my_secret (
   TYPE http,
     EXTRA_HTTP_HEADERS MAP {
       'X-Duck-Header': 'quack-quack'
     }
);
```

Note that adding such headers will make in most cases request bump from [Simple Requests](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header) to requiring CORS headers.

Error messages are mostly visible via browser console, given those are not bubbled up to JavaScript.

Also note, there are forbidden headers, but those are not validated.

This closes yet another gap between native and duckdb-wasm HTTP backend.