### PR TITLE
Change build config to be compatible with emscripten 3x

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -296,7 +296,7 @@ if(EMSCRIPTEN)
       -s MAXIMUM_MEMORY=4GB \
       -s MODULARIZE=1 \
       -s EXPORT_NAME='DuckDB' \
-      -s EXPORTED_RUNTIME_METHODS='[\"ccall\", \"stackSave\", \"stackAlloc\", \"stackRestore\", \"createDyncallWrapper\", \"getTempRet0\", \"setTempRet0\"]' \
+      -s EXPORTED_RUNTIME_METHODS='[\"ccall\", \"stackSave\", \"stackAlloc\", \"stackRestore\", \"HEAPF64\", \"HEAP8\", \"HEAPU8\", \"HEAP32\", \"HEAPU32\"]' \
       --js-library=${CMAKE_SOURCE_DIR}/js-stubs.js")
 
 endif()

--- a/packages/duckdb-wasm/bundle.mjs
+++ b/packages/duckdb-wasm/bundle.mjs
@@ -36,7 +36,7 @@ import { execSync } from 'child_process';
 // The lack of alternatives for Karma won't allow us to bundle workers and tests as ESM.
 // We should upgrade all CommonJS bundles to ESM as soon as the dynamic requires are resolved.
 
-const TARGET_BROWSER = ['chrome64', 'edge79', 'firefox62', 'safari11.1'];
+const TARGET_BROWSER = ['chrome90', 'edge90', 'firefox88', 'safari14'];
 const TARGET_BROWSER_TEST = ['es2020'];
 const TARGET_NODE = ['node14.6'];
 const EXTERNALS_NODE = ['apache-arrow'];
@@ -99,12 +99,24 @@ fs.copyFile(path.resolve(src, 'bindings', 'duckdb-eh.wasm'), path.resolve(dist, 
 fs.copyFile(path.resolve(src, 'bindings', 'duckdb-coi.wasm'), path.resolve(dist, 'duckdb-coi.wasm'), printErr);
 
 (async () => {
+    const nonBrowserModules = ['child_process', 'fs',
+        'crypto', 'node:crypto', 'node:fs', 'node:worker_threads', 'node:util', 'node:os'];
     // Don't attempt to bundle NodeJS modules in the browser build.
     console.log('[ ESBUILD ] Patch bindings');
-    patchFile('./src/bindings/duckdb-mvp.js', 'child_process');
-    patchFile('./src/bindings/duckdb-eh.js', 'child_process');
-    patchFile('./src/bindings/duckdb-coi.js', 'child_process');
-    patchFile('./src/bindings/duckdb-coi.pthread.js', 'vm');
+    patchFile('./src/bindings/duckdb-mvp.js', nonBrowserModules);
+    patchFile('./src/bindings/duckdb-eh.js', nonBrowserModules);
+    patchFile('./src/bindings/duckdb-coi.js', nonBrowserModules);
+
+    // Newer emscripten bundles the pthread worker
+    let coiWorkerExists = false;
+    try {
+        patchFile('./src/bindings/duckdb-coi.pthread.js', ['vm']);
+        coiWorkerExists = true;
+    }
+    catch(e) {
+
+    }
+    
 
     // -------------------------------
     // Browser bundles
@@ -358,13 +370,20 @@ fs.copyFile(path.resolve(src, 'bindings', 'duckdb-coi.wasm'), path.resolve(dist,
     }
 })();
 
-function patchFile(fileName, moduleName) {
+/**
+ * 
+ * @param {string} fileName 
+ * @param {string[]} moduleNames 
+ */
+function patchFile(fileName, moduleNames) {
     // Patch file to make sure ESBuild doesn't statically analyse and attempt to load "moduleName"
     // We replace both single and double-quoted module names. The character capture list complexity
     // is due to the single quote:
     // - the sed expression is executed within single quotes
     // - we have to terminate the quotes
     // - we have to escape the middle quote
-    const sedCommand = `s/require(["'\\'']${moduleName}["'\\''])/["${moduleName}"].map(require)/g`;
-    execSync(`sed -i.bak '${sedCommand}' ${fileName} && rm ${fileName}.bak`);
+    for(const moduleName of moduleNames) {
+        const sedCommand = `s/require(["'\\'']${moduleName}["'\\''])/["${moduleName}"].map(require)/g`;
+        execSync(`sed -i.bak '${sedCommand}' ${fileName} && rm ${fileName}.bak`);
+    }
 }

--- a/packages/duckdb-wasm/src/targets/duckdb-browser-coi.pthread.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-browser-coi.pthread.worker.ts
@@ -1,47 +1,29 @@
-import * as pthread_api from '../bindings/duckdb-coi.pthread';
-import DuckDB from '../bindings/duckdb-coi';
+import { DuckDB } from '../bindings/bindings_browser_coi';
+import { AsyncDuckDBDispatcher, WorkerResponseVariant, WorkerRequestVariant } from '../parallel';
 import { BROWSER_RUNTIME } from '../bindings/runtime_browser';
+import { InstantiationProgress } from '../bindings';
 
-// Register the global DuckDB runtime
-globalThis.DUCKDB_RUNTIME = {};
-for (const func of Object.getOwnPropertyNames(BROWSER_RUNTIME)) {
-    if (func == 'constructor') continue;
-    globalThis.DUCKDB_RUNTIME[func] = Object.getOwnPropertyDescriptor(BROWSER_RUNTIME, func)!.value;
+class WebWorker extends AsyncDuckDBDispatcher {
+    protected postMessage(response: WorkerResponseVariant, transfer: ArrayBuffer[]) {
+        globalThis.postMessage(response, transfer);
+    }
+
+    protected async instantiate(
+        mainModuleURL: string,
+        pthreadWorkerURL: string | null,
+        progress: (p: InstantiationProgress) => void,
+    ) {
+        // pthreadWorkerURL is ignored — Emscripten handles it internally
+        const bindings = new DuckDB(this, BROWSER_RUNTIME, mainModuleURL, null);
+        return await bindings.instantiate(progress);
+    }
 }
 
-// We just override the load handler of the pthread wrapper to bundle DuckDB with esbuild.
-globalThis.onmessage = (e: any) => {
-    if (e.data.cmd === 'load') {
-        let m = pthread_api.getModule();
+export function registerWorker() {
+    const api = new WebWorker();
+    globalThis.onmessage = async (event) => {
+        await api.onMessage(event.data);
+    };
+}
 
-        (globalThis as any).startWorker = (instance: any) => {
-            m = instance;
-            postMessage({ cmd: 'loaded' });
-        };
-        m['wasmModule'] = e.data.wasmModule;
-        m['wasmMemory'] = e.data.wasmMemory;
-        m['buffer'] = m['wasmMemory'].buffer;
-        m['ENVIRONMENT_IS_PTHREAD'] = true;
-        DuckDB(m).then((instance: any) => {
-            pthread_api.setModule(instance);
-        });
-    } else if (e.data.cmd === 'registerFileHandle') {
-        globalThis.DUCKDB_RUNTIME._files = globalThis.DUCKDB_RUNTIME._files || new Map();
-        globalThis.DUCKDB_RUNTIME._files.set(e.data.fileName, e.data.fileHandle);
-    } else if (e.data.cmd === 'dropFileHandle') {
-        globalThis.DUCKDB_RUNTIME._files = globalThis.DUCKDB_RUNTIME._files || new Map();
-        globalThis.DUCKDB_RUNTIME._files.delete(e.data.fileName);
-    } else if (e.data.cmd === 'registerUDFFunction') {
-        globalThis.DUCKDB_RUNTIME._udfFunctions = globalThis.DUCKDB_RUNTIME._files || new Map();
-        globalThis.DUCKDB_RUNTIME._udfFunctions.set(e.data.udf.name, e.data.udf);
-    } else if (e.data.cmd === 'dropUDFFunctions') {
-        globalThis.DUCKDB_RUNTIME._udfFunctions = globalThis.DUCKDB_RUNTIME._files || new Map();
-        for (const key of globalThis.DUCKDB_RUNTIME._udfFunctions.keys()) {
-            if (globalThis.DUCKDB_RUNTIME._udfFunctions.get(key).connection_id == e.data.connectionId) {
-                globalThis.DUCKDB_RUNTIME._udfFunctions.delete(key);
-            }
-        }
-    } else {
-        pthread_api.onmessage(e);
-    }
-};
+registerWorker();

--- a/scripts/wasm_build_lib.sh
+++ b/scripts/wasm_build_lib.sh
@@ -92,11 +92,7 @@ fi
 
 js-beautify -v || npm install -g js-beautify
 js-beautify ${BUILD_DIR}/duckdb_wasm.js > ${BUILD_DIR}/beauty.js
-sed 's/case \"__table_base\"/case \"getTempRet0\": return getTempRet0;   case \"__table_base\"/g' ${BUILD_DIR}/beauty.js > ${BUILD_DIR}/beauty_sed.js
-cp ${BUILD_DIR}/beauty_sed.js ${BUILD_DIR}/beauty.js
 cp ${BUILD_DIR}/beauty.js ${BUILD_DIR}/duckdb_wasm.js
-awk '{gsub(/get\(stubs, prop\) \{/,"get(stubs,prop) { if (prop.startsWith(\"invoke_\")) {return createDyncallWrapper(prop.substring(7));}"); print}' ${BUILD_DIR}/beauty.js > ${BUILD_DIR}/beauty2.js
-awk '!(/var .*wasmExports\[/ || /var [_a-z0-9A-Z]+ = Module\[\"[_a-z0-9A-Z]+\"\] = [0-9]+;/) || /var _duckdb_web/ || /var _main/ || /var _calloc/ || /var _malloc/ || /var _free/ || /var stack/ || /var ___dl_seterr/ || /var __em/ || /var _em/ || /var _pthread/' ${BUILD_DIR}/beauty2.js > ${BUILD_DIR}/duckdb_wasm.js
 
 cp ${BUILD_DIR}/duckdb_wasm.wasm ${DUCKDB_LIB_DIR}/duckdb${SUFFIX}.wasm
 sed \


### PR DESCRIPTION
This is a draft, there may be more changes needed. I did these changes for my own use, but I wanted to share in case someone else is considering updating from emscripten <= 3.0

So far, following was changed:

 - Bump browser versions slightly to allow for bigint literals that emscriptenn now emits
 - HEAPxxx now needs to be explicitly exported
 - An additional js file is no longer emitted for pthread workers, instead emscripten inlines it into the main worker