### PR TITLE
feat: forward worker console errors to shell terminal

### DIFF
--- a/packages/duckdb-wasm-shell/src/shell.ts
+++ b/packages/duckdb-wasm-shell/src/shell.ts
@@ -116,6 +116,27 @@ export async function embed(props: ShellProps) {
     const TERM_BOLD = '\x1b[1m';
     const TERM_NORMAL = '\x1b[m';
     const TERM_CLEAR = '\x1b[2K\r';
+    const TERM_YELLOW = '\x1b[33m';
+    const TERM_RED = '\x1b[31m';
+
+    // Forward console.warn and console.error to the shell terminal so users
+    // can see errors (e.g. CORS, network failures) without opening DevTools.
+    const trueConsoleWarn = console.warn.bind(console);
+    const trueConsoleError = console.error.bind(console);
+    const formatLogArgs = (args: any[]): string => {
+        if (args.length === 1 && args[0] !== null && typeof args[0] === 'object' && 'value' in args[0]) {
+            return String(args[0].value);
+        }
+        return args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+    };
+    console.warn = function (...args: any[]) {
+        shell.writeln(`${TERM_YELLOW}${TERM_BOLD}[ WARN ]${TERM_NORMAL} ${formatLogArgs(args)}`);
+        trueConsoleWarn(...args);
+    };
+    console.error = function (...args: any[]) {
+        shell.writeln(`${TERM_RED}${TERM_BOLD}[ ERR  ]${TERM_NORMAL} ${formatLogArgs(args)}`);
+        trueConsoleError(...args);
+    };
 
     // Progress handler
     const progressHandler = (progress: InstantiationProgress) => {

--- a/packages/duckdb-wasm/src/log.ts
+++ b/packages/duckdb-wasm/src/log.ts
@@ -62,7 +62,9 @@ export type LogEntryVariant =
     | LogEntry<LogOrigin.BINDINGS, LogTopic.OPEN, LogEvent.START, void>
     | LogEntry<LogOrigin.BINDINGS, LogTopic.OPEN, LogEvent.OK, void>
     | LogEntry<LogOrigin.BINDINGS, LogTopic.OPEN, LogEvent.ERROR, void>
-    | LogEntry<LogOrigin.ASYNC_DUCKDB, LogTopic.QUERY, LogEvent.RUN, string>;
+    | LogEntry<LogOrigin.ASYNC_DUCKDB, LogTopic.QUERY, LogEvent.RUN, string>
+    | LogEntry<LogOrigin.WEB_WORKER, LogTopic.NONE, LogEvent.CAPTURE, string>
+    | LogEntry<LogOrigin.NODE_WORKER, LogTopic.NONE, LogEvent.CAPTURE, string>;
 
 export interface Logger {
     log(entry: LogEntryVariant): void;
@@ -76,7 +78,13 @@ export class ConsoleLogger implements Logger {
     constructor(protected level: LogLevel = LogLevel.INFO) {}
     public log(entry: LogEntryVariant): void {
         if (entry.level >= this.level) {
-            console.log(entry);
+            if (entry.level >= LogLevel.ERROR) {
+                console.error(entry);
+            } else if (entry.level >= LogLevel.WARNING) {
+                console.warn(entry);
+            } else {
+                console.log(entry);
+            }
         }
     }
 }

--- a/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
+++ b/packages/duckdb-wasm/src/parallel/worker_dispatcher.ts
@@ -1,6 +1,6 @@
 import { DuckDBBindings, DuckDBDataProtocol } from '../bindings';
 import { WorkerResponseVariant, WorkerRequestVariant, WorkerRequestType, WorkerResponseType } from './worker_request';
-import { Logger, LogEntryVariant } from '../log';
+import { Logger, LogEntryVariant, LogLevel, LogOrigin, LogTopic, LogEvent } from '../log';
 import { InstantiationProgress } from '../bindings/progress';
 
 export abstract class AsyncDuckDBDispatcher implements Logger {
@@ -29,6 +29,36 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
             },
             [],
         );
+    }
+
+    /** Intercept console.warn and console.error to forward them to the main thread.
+     *  Must be called once per worker, before any DuckDB operations. */
+    public interceptConsole(origin: LogOrigin.WEB_WORKER | LogOrigin.NODE_WORKER = LogOrigin.WEB_WORKER): void {
+        const trueWarn = console.warn.bind(console);
+        const trueError = console.error.bind(console);
+        const self = this;
+        console.warn = function (...args: any[]) {
+            self.log({
+                timestamp: new Date(),
+                level: LogLevel.WARNING,
+                origin,
+                topic: LogTopic.NONE,
+                event: LogEvent.CAPTURE,
+                value: args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '),
+            });
+            trueWarn(...args);
+        };
+        console.error = function (...args: any[]) {
+            self.log({
+                timestamp: new Date(),
+                level: LogLevel.ERROR,
+                origin,
+                topic: LogTopic.NONE,
+                event: LogEvent.CAPTURE,
+                value: args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '),
+            });
+            trueError(...args);
+        };
     }
 
     /** Send plain OK without further data */
@@ -90,7 +120,6 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
                     });
                     this.sendOK(request);
                 } catch (e: any) {
-                    console.log(e);
                     this._bindings = null;
                     this.failWith(request, e);
                 }
@@ -408,7 +437,6 @@ export abstract class AsyncDuckDBDispatcher implements Logger {
                 }
             }
         } catch (e: any) {
-            console.log(e);
             return this.failWith(request, e);
         }
     }

--- a/packages/duckdb-wasm/src/targets/duckdb-browser-coi.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-browser-coi.worker.ts
@@ -25,6 +25,7 @@ class WebWorker extends AsyncDuckDBDispatcher {
 /** Register the worker */
 export function registerWorker(): void {
     const api = new WebWorker();
+    api.interceptConsole();
     globalThis.onmessage = async (event: MessageEvent<WorkerRequestVariant>) => {
         await api.onMessage(event.data);
     };

--- a/packages/duckdb-wasm/src/targets/duckdb-browser-eh.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-browser-eh.worker.ts
@@ -25,6 +25,7 @@ class WebWorker extends AsyncDuckDBDispatcher {
 /** Register the worker */
 export function registerWorker(): void {
     const api = new WebWorker();
+    api.interceptConsole();
     globalThis.onmessage = async (event: MessageEvent<WorkerRequestVariant>) => {
         await api.onMessage(event.data);
     };

--- a/packages/duckdb-wasm/src/targets/duckdb-browser-mvp.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-browser-mvp.worker.ts
@@ -25,6 +25,7 @@ class WebWorker extends AsyncDuckDBDispatcher {
 /** Register the worker */
 export function registerWorker(): void {
     const api = new WebWorker();
+    api.interceptConsole();
     globalThis.onmessage = async (event: MessageEvent<WorkerRequestVariant>) => {
         await api.onMessage(event.data);
     };

--- a/packages/duckdb-wasm/src/targets/duckdb-node-eh.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-node-eh.worker.ts
@@ -1,4 +1,5 @@
 import { AsyncDuckDBDispatcher, WorkerResponseVariant, WorkerRequestVariant } from '../parallel/';
+import { LogOrigin } from '../log';
 import { DuckDBBindings } from '../bindings';
 import { DuckDB } from '../bindings/bindings_node_eh';
 import { NODE_RUNTIME } from '../bindings/runtime_node';
@@ -25,6 +26,7 @@ class NodeWorker extends AsyncDuckDBDispatcher {
 /** Register the worker */
 export function registerWorker(): void {
     const api = new NodeWorker();
+    api.interceptConsole(LogOrigin.NODE_WORKER);
     globalThis.onmessage = async (event: MessageEvent<WorkerRequestVariant>) => {
         await api.onMessage(event.data);
     };

--- a/packages/duckdb-wasm/src/targets/duckdb-node-mvp.worker.ts
+++ b/packages/duckdb-wasm/src/targets/duckdb-node-mvp.worker.ts
@@ -1,4 +1,5 @@
 import { AsyncDuckDBDispatcher, WorkerResponseVariant, WorkerRequestVariant } from '../parallel/';
+import { LogOrigin } from '../log';
 import { DuckDBBindings } from '../bindings';
 import { DuckDB } from '../bindings/bindings_node_mvp';
 import { NODE_RUNTIME } from '../bindings/runtime_node';
@@ -25,6 +26,7 @@ class NodeWorker extends AsyncDuckDBDispatcher {
 /** Register the worker */
 export function registerWorker(): void {
     const api = new NodeWorker();
+    api.interceptConsole(LogOrigin.NODE_WORKER);
     globalThis.onmessage = async (event: MessageEvent<WorkerRequestVariant>) => {
         await api.onMessage(event.data);
     };


### PR DESCRIPTION
## Summary

Fixes #1244.

Errors from `console.warn`/`console.error` in the WebWorker (e.g. CORS failures, network errors) were only visible in browser DevTools. Users had no way to see what went wrong without opening DevTools.

This change:
- Intercepts `console.warn`/`console.error` in all browser and Node workers via a new `interceptConsole()` method on `AsyncDuckDBDispatcher`
- Forwards captured messages to the main thread using the existing `postMessage` log channel
- Displays them in the shell terminal with color-coded `[ WARN ]` and `[ ERR ]` prefixes

## Test

Ran the following in the local shell:

```sql
SET s3_region='us-east-1';
SELECT count(*) FROM read_parquet('s3://nonexistent-bucket-duckdb-test/test.parquet');
```

Before: error only visible in DevTools console.
After: error appears directly in the shell terminal.

<img width="1583" height="1013" alt="image" src="https://github.com/user-attachments/assets/0287bab6-1b6f-4beb-b45d-2eaa3b9f82a9" />


## Files changed

- `packages/duckdb-wasm/src/log.ts` — new `LogEntryVariant` types for worker console captures; `ConsoleLogger` now routes to `console.warn`/`console.error` by level
- `packages/duckdb-wasm/src/parallel/worker_dispatcher.ts` — new `interceptConsole()` method
- `packages/duckdb-wasm/src/targets/duckdb-browser-{eh,mvp,coi}.worker.ts` — call `interceptConsole()`
- `packages/duckdb-wasm/src/targets/duckdb-node-{eh,mvp}.worker.ts` — call `interceptConsole(LogOrigin.NODE_WORKER)`
- `packages/duckdb-wasm-shell/src/shell.ts` — intercepts `console.warn`/`console.error` on the main thread and writes to the terminal
