### PR TITLE
Enhance OPFS file handling

### DIFF
--- a/packages/duckdb-wasm/src/parallel/async_bindings.ts
+++ b/packages/duckdb-wasm/src/parallel/async_bindings.ts
@@ -18,7 +18,7 @@ import { InstantiationProgress } from '../bindings/progress';
 import { arrowToSQLField } from '../json_typedef';
 import { WebFile } from '../bindings/web_file';
 import { DuckDBDataProtocol } from '../bindings';
-import { searchOPFSFiles, isOPFSProtocol } from "../utils/opfs_util";
+import { searchOPFSFiles } from "../utils/opfs_util";
 import { ProgressEntry } from '../log';
 
 const TEXT_ENCODER = new TextEncoder();
@@ -707,11 +707,8 @@ export class AsyncDuckDB implements AsyncDuckDBBindings {
         await this.postTask(task);
     }
 
-    private shouldOPFSFileHandling():boolean {
-        if( isOPFSProtocol(this.config.path ?? "")){
-            return this.config.opfs?.fileHandling == "auto";
-        }
-        return false;
+    private shouldOPFSFileHandling(): boolean {
+        return this.config.opfs?.fileHandling === 'auto';
     }
 
     private async registerOPFSFileFromSQL(text: string) {

--- a/packages/duckdb-wasm/src/utils/opfs_util.ts
+++ b/packages/duckdb-wasm/src/utils/opfs_util.ts
@@ -1,4 +1,4 @@
-export const REGEX_OPFS_FILE = /'(opfs:\/\/\S*?)'/g;
+export const REGEX_OPFS_FILE = /(['"])(opfs:\/\/\S*?)\1/g;
 export const REGEX_OPFS_PROTOCOL = /(opfs:\/\/\S*?)/g;
 
 export function isOPFSProtocol(path: string): boolean {
@@ -6,5 +6,5 @@ export function isOPFSProtocol(path: string): boolean {
 }
 
 export function searchOPFSFiles(text: string) {
-    return [...text.matchAll(REGEX_OPFS_FILE)].map(match => match[1]);
+    return [...text.matchAll(REGEX_OPFS_FILE)].map(match => match[2]);
 }

--- a/packages/duckdb-wasm/test/opfs.test.ts
+++ b/packages/duckdb-wasm/test/opfs.test.ts
@@ -396,6 +396,61 @@ export function testOPFS(baseDir: string, bundle: () => DuckDBBundle): void {
                 new BigInt64Array([42n]),
             );
         });
+
+        describe('Enhanced OPFS Support', () => {
+            it('should auto-register opfs:// files with an in-memory database', async () => {
+                await getOpfsFileHandlerFromUrl({
+                    url: `${baseDir}/uni/studenten.parquet`,
+                    path: 'test_enhanced.parquet'
+                });
+
+                await conn.close();
+                await db.reset();
+                await db.open({
+                    path: ':memory:',
+                    opfs: { fileHandling: 'auto' }
+                });
+                conn = await db.connect();
+
+                const result = await conn.send(`SELECT COUNT(*)::INT as cnt FROM 'opfs://test_enhanced.parquet'`);
+                const table = await arrow.tableFromIPC(result);
+                expect(table.getChildAt(0)?.get(0)).toBe(8);
+            });
+
+            it('should support double quotes for opfs:// files', async () => {
+                await getOpfsFileHandlerFromUrl({
+                    url: `${baseDir}/uni/studenten.parquet`,
+                    path: 'test_enhanced.parquet'
+                });
+
+                await conn.close();
+                await db.reset();
+                await db.open({
+                    path: ':memory:',
+                    opfs: { fileHandling: 'auto' }
+                });
+                conn = await db.connect();
+
+                // Verification of double quote support
+                const result = await conn.send(`SELECT COUNT(*)::INT as cnt FROM "opfs://test_enhanced.parquet"`);
+                const table = await arrow.tableFromIPC(result);
+                expect(table.getChildAt(0)?.get(0)).toBe(8);
+            });
+
+            it('should fail gracefully if opfs:// file is missing with auto-registration', async () => {
+                await conn.close();
+                await db.reset();
+                await db.open({
+                    path: ':memory:',
+                    opfs: { fileHandling: 'auto' }
+                });
+                conn = await db.connect();
+
+                await expectAsync(
+                    conn.send(`SELECT * FROM 'opfs://missing.parquet'`)
+                ).toBeRejected();
+            });
+        });
     });
 
     async function removeFiles() {
@@ -407,6 +462,7 @@ export function testOPFS(baseDir: string, bundle: () => DuckDBBundle): void {
         await opfsRoot.removeEntry('test2.csv').catch(_ignore);
         await opfsRoot.removeEntry('test3.csv').catch(_ignore);
         await opfsRoot.removeEntry('test.parquet').catch(_ignore);
+        await opfsRoot.removeEntry('test_enhanced.parquet').catch(_ignore);
         try {
             const datadir = await opfsRoot.getDirectoryHandle('datadir');
             datadir.removeEntry('test.parquet').catch(_ignore);


### PR DESCRIPTION
Thank you for the great project.

This PR enhances OPFS file handling.

# Summary

## 1. Automatic OPFS File Registration for Queries
Previously, automatic OPFS file handling was active only when the main database itself was stored in OPFS.
This PR extends that functionality to all queries, regardless of the database path (e.g., including `:memory:` databases).
 
With `opfs: { fileHandling: 'auto' }` configuration, the engine now extracts `opfs://` URIs from SQL statements and ensures they are registered before execution.
This eliminates the need for manual `registerOPFSFileName` calls and (partially) fixes the async race conditions/timing issue https://github.com/duckdb/duckdb-wasm/issues/1975.


## 2. Support for Double-Quoted OPFS Paths

Although DuckDB allows users to use double quote for file path,
The regex `REGEX_OPFS_FILE` only matched to single quoted path (aka. `'opfs://...'`).
This PR adds support for double quoted one (aka. `"opfs://..."`), too.

# Testing
I added three test cases;
- Auto-registration of files with an in-memory database.
- Support for double-quoted paths.
- Graceful handling of missing OPFS files.

and verified that all the new tests and existing tests pass on GitHub Actions.
https://github.com/ymd-h/duckdb-wasm/actions/runs/25862701976