### PR TITLE
fix: patch OPFS persistence gaps in duckdb-wasm runtime

### DIFF
--- a/packages/duckdb-wasm/src/bindings/bindings_base.ts
+++ b/packages/duckdb-wasm/src/bindings/bindings_base.ts
@@ -516,7 +516,7 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
             const list = await this._runtime.prepareFileHandles([fileName], DuckDBDataProtocol.BROWSER_FSACCESS);
             for (const item of list) {
                 const { handle, path: filePath, fromCached } = item;
-                if (!fromCached && handle.getSize()) {
+                if (!fromCached) {
                     await this.registerFileHandleAsync(filePath, handle, DuckDBDataProtocol.BROWSER_FSACCESS, true);
                 }
             }
@@ -530,7 +530,7 @@ export abstract class DuckDBBindingsBase implements DuckDBBindings {
             const list = await this._runtime.prepareDBFileHandle(path, DuckDBDataProtocol.BROWSER_FSACCESS);
             for (const item of list) {
                 const { handle, path: filePath, fromCached } = item;
-                if (!fromCached && handle.getSize()) {
+                if (!fromCached) {
                     await this.registerFileHandleAsync(filePath, handle, DuckDBDataProtocol.BROWSER_FSACCESS, true);
                 }
             }

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -525,7 +525,15 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         }
         return false;
     },
-    syncFile: (_mod: DuckDBModule, _fileId: number) => {},
+    syncFile: (mod: DuckDBModule, fileId: number) => {
+        const file = BROWSER_RUNTIME.getFileInfo(mod, fileId);
+        if (file?.dataProtocol === DuckDBDataProtocol.BROWSER_FSACCESS) {
+            const handle: FileSystemSyncAccessHandle = BROWSER_RUNTIME._files?.get(file.fileName);
+            if (handle) {
+                handle.flush();
+            }
+        }
+    },
     closeFile: (mod: DuckDBModule, fileId: number) => {
         const file = BROWSER_RUNTIME.getFileInfo(mod, fileId);
         BROWSER_RUNTIME._fileInfoCache.delete(fileId);
@@ -541,10 +549,10 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                     return;
                 case DuckDBDataProtocol.BROWSER_FSACCESS: {
                     const handle: FileSystemSyncAccessHandle = BROWSER_RUNTIME._files?.get(file.fileName);
-                    if (!handle) {
-                        throw new Error(`No OPFS access handle registered with name: ${file.fileName}`);
+                    if (handle) {
+                        handle.flush();
                     }
-                    return handle.flush();
+                    return;
                 }
             }
         } catch (e: any) {
@@ -758,7 +766,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         const to = readString(mod, toPtr, toLen);
         const handle = BROWSER_RUNTIME._files?.get(from);
         if (handle !== undefined) {
-            BROWSER_RUNTIME._files!.delete(handle);
+            BROWSER_RUNTIME._files!.delete(from);
             BROWSER_RUNTIME._files!.set(to, handle);
         }
         for (const [key, value] of BROWSER_RUNTIME._fileInfoCache?.entries() || []) {
@@ -769,7 +777,34 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         }
         return true;
     },
-    removeFile: (_mod: DuckDBModule, _pathPtr: number, _pathLen: number) => {},
+    removeFile: (mod: DuckDBModule, pathPtr: number, pathLen: number) => {
+        const path = readString(mod, pathPtr, pathLen);
+        const handle = BROWSER_RUNTIME._files?.get(path);
+        if (handle) {
+            try {
+                handle.flush();
+                handle.close();
+            } catch (_e) {}
+            BROWSER_RUNTIME._files!.delete(path);
+        }
+        for (const [key, value] of BROWSER_RUNTIME._fileInfoCache?.entries() || []) {
+            if (value.dataUrl == path) {
+                BROWSER_RUNTIME._fileInfoCache.delete(key);
+                break;
+            }
+        }
+        if (globalThis.DUCKDB_RUNTIME._preparedHandles?.[path]) {
+            delete globalThis.DUCKDB_RUNTIME._preparedHandles[path];
+        }
+        try {
+            const opfsRoot = navigator.storage.getDirectory();
+            // SyncAccessHandle is sync but getDirectory is async — best-effort cleanup via _pendingDeletes
+            if (!globalThis.DUCKDB_RUNTIME._pendingDeletes) {
+                globalThis.DUCKDB_RUNTIME._pendingDeletes = [];
+            }
+            globalThis.DUCKDB_RUNTIME._pendingDeletes.push(path);
+        } catch (_e) {}
+    },
     callScalarUDF: (
         mod: DuckDBModule,
         response: number,


### PR DESCRIPTION
5 patches to fix OPFS file persistence:
1. bindings_base: register zero-byte DB/WAL handles (remove getSize() guard)
2. runtime_browser: implement syncFile with handle.flush() for OPFS
3. runtime_browser: fix moveFile delete-by-value bug (delete(from) not delete(handle))
4. runtime_browser: implement removeFile with OPFS handle cleanup
5. runtime_browser: closeFile gracefully handles missing OPFS handle