### PR TITLE
Allow opening and dropping of OPFS databases

### DIFF
--- a/lib/include/duckdb/web/io/buffered_filesystem.h
+++ b/lib/include/duckdb/web/io/buffered_filesystem.h
@@ -141,6 +141,9 @@ class BufferedFileSystem : public duckdb::FileSystem {
         return filesystem_.Glob(PatchFilenameOwned(path), opener);
     }
 
+    /// Overide canonicalize path to allow for OPFS:// path urls
+    string CanonicalizePath(const string &path_p, optional_ptr<FileOpener> opener = nullptr) override;
+
     /// Register subsystem
     void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override;
     /// Register subsystem

--- a/lib/src/io/buffered_filesystem.cc
+++ b/lib/src/io/buffered_filesystem.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/web/io/buffered_filesystem.h"
 #include "duckdb/web/io/file_page_buffer.h"
@@ -244,6 +245,16 @@ void BufferedFileSystem::RemoveFile(const std::string &raw_filename, optional_pt
     auto filename = PatchFilenameOwned(raw_filename);
     // XXX Invalidate buffer manager!
     return filesystem_.RemoveFile(filename);
+}
+
+/// Canonicalize a path - preserve opfs:// protocol prefix (double slash) which DuckDB's
+/// base CanonicalizePath would collapse to opfs:/ since opfs:// is not in EXTENSION_FILE_PREFIXES.
+/// opfs:// is a local file that looks like a remote file, so IsRemoteFile won't short-circuit it.
+string BufferedFileSystem::CanonicalizePath(const string &path_p, optional_ptr<FileOpener> opener) {
+    if (StringUtil::StartsWith(path_p, "opfs://")) {
+        return path_p;
+    }
+    return filesystem_.CanonicalizePath(path_p, opener);
 }
 
 /// Register subsystem

--- a/lib/src/io/file_page_buffer.cc
+++ b/lib/src/io/file_page_buffer.cc
@@ -639,6 +639,7 @@ void FilePageBuffer::FileRef::ReOpen(FileOpenFlags flags) {
     auto new_handle = buffer_.filesystem->OpenFile(file_->path, flags);
     // Swap the file handles
     std::swap(new_handle, file_->handle);
+    file_->file_flags = flags;
 }
 
 /// Buffers a file at a path.

--- a/lib/src/io/web_filesystem.cc
+++ b/lib/src/io/web_filesystem.cc
@@ -993,7 +993,6 @@ void WebFileSystem::MoveFile(const std::string &source, const std::string &targe
             files_by_url_.erase(iter);
             files_by_url_.insert({target, file});
         }
-
     }
     if (auto iter = files_by_name_.find(source); iter != files_by_name_.end()) {
         auto file = std::move(iter->second);
@@ -1003,7 +1002,6 @@ void WebFileSystem::MoveFile(const std::string &source, const std::string &targe
             files_by_name_.erase(iter);
             files_by_name_.insert({target, file});
         }
-
     }
 
     duckdb_web_fs_file_move(source.c_str(), source.size(), target.c_str(), target.size());

--- a/lib/src/io/web_filesystem.cc
+++ b/lib/src/io/web_filesystem.cc
@@ -984,18 +984,28 @@ bool WebFileSystem::ListFiles(const std::string &directory,
 /// properties
 void WebFileSystem::MoveFile(const std::string &source, const std::string &target, optional_ptr<FileOpener> opener) {
     std::unique_lock<LightMutex> fs_guard{fs_mutex_};
+
     if (auto iter = files_by_url_.find(source); iter != files_by_url_.end()) {
         auto file = std::move(iter->second);
-        file->data_url_ = target;
-        files_by_url_.erase(iter);
-        files_by_url_.insert({target, file});
+        // OPFS files are moved by the JS VFS
+        if (file->GetDataProtocol() != BROWSER_FSACCESS) {
+            file->data_url_ = target;
+            files_by_url_.erase(iter);
+            files_by_url_.insert({target, file});
+        }
+
     }
     if (auto iter = files_by_name_.find(source); iter != files_by_name_.end()) {
         auto file = std::move(iter->second);
-        file->file_name_ = target;
-        files_by_name_.erase(iter);
-        files_by_name_.insert({target, file});
+        // OPFS Files are moved by the JS VFS
+        if (file->GetDataProtocol() != BROWSER_FSACCESS) {
+            file->file_name_ = target;
+            files_by_name_.erase(iter);
+            files_by_name_.insert({target, file});
+        }
+
     }
+
     duckdb_web_fs_file_move(source.c_str(), source.size(), target.c_str(), target.size());
 }
 /// Check if a file exists

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -151,11 +151,11 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
                     throw e;
                 });
                 try {
-                    const handle = await fileHandle.createSyncAccessHandle();
-                    BROWSER_RUNTIME._preparedHandles[path] = handle;
+                    const syncHandle = await fileHandle.createSyncAccessHandle();
+                    BROWSER_RUNTIME._preparedHandles[path] = syncHandle;
                     return {
                         path,
-                        handle,
+                        handle: syncHandle,
                         fromCached: false,
                     };
                 } catch (e: any) {

--- a/packages/duckdb-wasm/src/bindings/runtime_browser.ts
+++ b/packages/duckdb-wasm/src/bindings/runtime_browser.ts
@@ -115,13 +115,15 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         if (protocol === DuckDBDataProtocol.BROWSER_FSACCESS) {
             await BROWSER_RUNTIME.assignOPFSRoot();
             const prepare = async (path: string): Promise<PreparedDBFileHandle> => {
-                if (BROWSER_RUNTIME._files.has(path)) {
+                const handle = BROWSER_RUNTIME._files.get(path) || BROWSER_RUNTIME._preparedHandles[path];
+                if (handle) {
                     return {
                         path,
-                        handle: BROWSER_RUNTIME._files.get(path),
+                        handle,
                         fromCached: true,
                     };
                 }
+
                 const opfsRoot = BROWSER_RUNTIME._opfsRoot!;
                 let dirHandle: FileSystemDirectoryHandle = opfsRoot;
                 // check if mkdir -p is needed
@@ -172,7 +174,7 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
     /** Prepare a file handle that could only be acquired aschronously */
     async prepareDBFileHandle(dbPath: string, protocol: DuckDBDataProtocol): Promise<PreparedDBFileHandle[]> {
         if (protocol === DuckDBDataProtocol.BROWSER_FSACCESS && this.prepareFileHandles) {
-            const filePaths = [dbPath, `${dbPath}.wal`];
+            const filePaths = [dbPath, `${dbPath}.wal`, `${dbPath}.wal.checkpoint`, `${dbPath}.wal.recovery`];
             return this.prepareFileHandles(filePaths, protocol);
         }
         throw new Error(`Unsupported protocol ${protocol} for path ${dbPath} with protocol ${protocol}`);
@@ -554,8 +556,8 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
     },
     dropFile: (mod: DuckDBModule, fileNamePtr: number, fileNameLen: number) => {
         const fileName = readString(mod, fileNamePtr, fileNameLen);
-        const handle: FileSystemSyncAccessHandle = BROWSER_RUNTIME._files?.get(fileName);
-        if (handle) {
+        if (BROWSER_RUNTIME._files?.has(fileName)) {
+            const handle = BROWSER_RUNTIME._files?.get(fileName);
             BROWSER_RUNTIME._files.delete(fileName);
             if (handle instanceof FileSystemSyncAccessHandle) {
                 try {
@@ -568,7 +570,16 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
             if (handle instanceof Blob) {
                 // nothing
             }
+        } else if (BROWSER_RUNTIME._preparedHandles[fileName]){
+            // File was prepared but not used.
+            const handle = BROWSER_RUNTIME._preparedHandles[fileName];
+            if (handle instanceof FileSystemSyncAccessHandle) {
+                delete BROWSER_RUNTIME._preparedHandles[fileName];
+                handle.flush();
+                handle.close();
+            }
         }
+
     },
     truncateFile: (mod: DuckDBModule, fileId: number, newSize: number) => {
         const file = BROWSER_RUNTIME.getFileInfo(mod, fileId);
@@ -757,8 +768,37 @@ export const BROWSER_RUNTIME: DuckDBRuntime & {
         const from = readString(mod, fromPtr, fromLen);
         const to = readString(mod, toPtr, toLen);
         const handle = BROWSER_RUNTIME._files?.get(from);
-        if (handle !== undefined) {
-            BROWSER_RUNTIME._files!.delete(handle);
+
+        // if we have a sync handle we need to reuse files
+        if (handle instanceof FileSystemSyncAccessHandle) {
+            const to_handle = BROWSER_RUNTIME._files?.get(to);
+            if (to_handle === undefined) {
+                throw new Error(`Not implemented error move from OPFS into non existent file`);
+            } else if (!(to_handle instanceof FileSystemSyncAccessHandle)) {
+                throw new Error(`Not implemented error move from OPFS into non OPFS file`);
+            }
+            // We have x -> y, y will be destroyed in this process.
+            // y is truncated so it is an empty file and stored as x.
+            to_handle.truncate(0);
+            const size = handle.getSize();
+            // Reads need to go somewhere copy data in one MB chunks.
+            const fileContents = new ArrayBuffer(Math.min(size, 1024 * 1024));
+            let bytes_read = 0;
+            for (let offset = 0; offset < size; offset += bytes_read) {
+                bytes_read = handle.read(fileContents, { at: offset });
+                to_handle.write(fileContents, { at: offset });
+            }
+            // Ensure that the from handle is empty again
+            handle.truncate(0);
+            // We do not remove files from the runtime as they would otherwise not
+            // be able to be dropped
+        } else if (handle !== undefined) {
+            const to_handle = BROWSER_RUNTIME._files?.get(to);
+            if (to_handle instanceof FileSystemSyncAccessHandle) {
+                throw new Error(`Not implemented move from arbitrary file into OPFS file`);
+            }
+
+            BROWSER_RUNTIME._files!.delete(from);
             BROWSER_RUNTIME._files!.set(to, handle);
         }
         for (const [key, value] of BROWSER_RUNTIME._fileInfoCache?.entries() || []) {

--- a/packages/duckdb-wasm/test/httpfs_test.ts
+++ b/packages/duckdb-wasm/test/httpfs_test.ts
@@ -307,20 +307,6 @@ export function testHTTPFSAsync(
             ).toBeRejected();
         });
 
-        it('write after read throws incorrect flag error without dropping files', async () => {
-            await setAwsConfig(conn!);
-            await conn!.query(
-                `COPY (SELECT * FROM range(1000,1010) tbl(i)) TO 's3://${BUCKET_NAME}/test_written.csv' (FORMAT 'csv');`,
-            );
-            const result = await conn!.query(`SELECT * FROM "s3://${BUCKET_NAME}/test_written.csv";`);
-            expect(Number(result.getChildAt(0)?.get(6))).toEqual(Number(1006));
-            await expectAsync(
-                conn!.query(
-                    `COPY (SELECT * FROM range(2000,2010) tbl(i)) TO 's3://${BUCKET_NAME}/test_written.csv' (FORMAT 'csv');`,
-                ),
-            ).toBeRejectedWithError('Invalid Error: File is not opened in write mode');
-        });
-
         it('can read parquet file from URL with long query string', async () => {
             // Create S3 file
             const data = await resolveData('/uni/studenten.parquet');

--- a/packages/duckdb-wasm/test/opfs.test.ts
+++ b/packages/duckdb-wasm/test/opfs.test.ts
@@ -105,8 +105,6 @@ export function testOPFS(baseDir: string, bundle: () => DuckDBBundle): void {
                 accessMode: DuckDBAccessMode.READ_WRITE
             });
             conn = await db.connect();
-            
-            return; //FIXME
 
             const result = await conn.send(`SELECT count(*) ::INTEGER as cnt FROM tmp;`);
             const batches = [];
@@ -115,6 +113,66 @@ export function testOPFS(baseDir: string, bundle: () => DuckDBBundle): void {
             }
             const table = await new arrow.Table<{ cnt: arrow.Int }>(batches);
             expect(table.getChildAt(0)?.get(0)).toBeGreaterThan(60_000);
+        });
+
+        it('Create database and delete files without error', async () => {
+            const registerFiles = async (db: AsyncDuckDB) => {
+                await db.registerOPFSFileName('opfs://temp.db');
+                await db.registerOPFSFileName('opfs://temp.db.wal');
+                await db.registerOPFSFileName('opfs://temp.db.wal.checkpoint');
+                await db.registerOPFSFileName('opfs://temp.db.wal.recovery');
+            };
+
+            const dropFiles = async (db: AsyncDuckDB) => {
+                await db.dropFiles([
+                    'opfs://temp.db',
+                    'opfs://temp.db.wal',
+                    'opfs://temp.db.wal.checkpoint',
+                    'opfs://temp.db.wal.recovery',
+                ]);
+            }
+
+            await registerFiles(db);
+            await conn.query("ATTACH 'opfs://temp.db' as opfs_db;");
+            await conn.query("CREATE TABLE opfs_db.t (x VARCHAR)");
+            await conn.query("INSERT INTO opfs_db.t VALUES ('hello world')");
+            await conn.query('DETACH opfs_db;');
+            await dropFiles(db);
+
+            // A second instance should now be able to read the created files.
+            // Without error, as there should be no lingering OPFS handles.
+            const worker = new Worker(bundle().mainWorker!);
+            const db2 = new AsyncDuckDB(logger, worker);
+            await db2.instantiate(bundle().mainModule, bundle().pthreadWorker);
+            await db2.open({ });
+            const conn2 = await db2.connect();
+            await registerFiles(db2);
+
+            await conn2.query("ATTACH 'opfs://temp.db' as opfs_db;");
+            const result = await conn2.send("SELECT * FROM opfs_db.t");
+            const batches = [];
+            for await (const batch of result) {
+                batches.push(batch);
+            }
+            const content = await new arrow.Table<{ t: arrow.Utf8 }>(batches).toArray();
+            expect(content.length).toBe(1);
+            expect(content[0].x).toBe('hello world');
+
+            await conn2.query('DETACH opfs_db;');
+            await dropFiles(db2);
+
+            // Delete files, will error if there is still a handle open
+            const opfsRoot = await navigator.storage.getDirectory();
+            const handle = opfsRoot.getFileHandle('temp.db');
+            expect((await (await handle).getFile()).size).toBeGreaterThan(0);
+            expect(async () => {
+                await opfsRoot.removeEntry('temp.db');
+                await opfsRoot.removeEntry('temp.db.wal');
+                await opfsRoot.removeEntry('temp.db.wal.checkpoint');
+                await opfsRoot.removeEntry('temp.db.wal.recovery');
+            }).not.toThrow()
+            conn2.close();
+            db2.terminate();
         });
 
         it('Load Parquet file that are already with empty handler', async () => {
@@ -402,6 +460,8 @@ export function testOPFS(baseDir: string, bundle: () => DuckDBBundle): void {
         const opfsRoot = await navigator.storage.getDirectory();
         await opfsRoot.removeEntry('test.db').catch(_ignore);
         await opfsRoot.removeEntry('test.db.wal').catch(_ignore);
+        await opfsRoot.removeEntry('test.db.wal.checkpoint').catch(_ignore);
+        await opfsRoot.removeEntry('test.db.wal.recovery').catch(_ignore);
         await opfsRoot.removeEntry('test.csv').catch(_ignore);
         await opfsRoot.removeEntry('test1.csv').catch(_ignore);
         await opfsRoot.removeEntry('test2.csv').catch(_ignore);

--- a/packages/duckdb-wasm/test/opfs.test.ts
+++ b/packages/duckdb-wasm/test/opfs.test.ts
@@ -116,15 +116,15 @@ export function testOPFS(baseDir: string, bundle: () => DuckDBBundle): void {
         });
 
         it('Create database and delete files without error', async () => {
-            const registerFiles = async (db: AsyncDuckDB) => {
-                await db.registerOPFSFileName('opfs://temp.db');
-                await db.registerOPFSFileName('opfs://temp.db.wal');
-                await db.registerOPFSFileName('opfs://temp.db.wal.checkpoint');
-                await db.registerOPFSFileName('opfs://temp.db.wal.recovery');
+            const registerFiles = async (instance: AsyncDuckDB) => {
+                await instance.registerOPFSFileName('opfs://temp.db');
+                await instance.registerOPFSFileName('opfs://temp.db.wal');
+                await instance.registerOPFSFileName('opfs://temp.db.wal.checkpoint');
+                await instance.registerOPFSFileName('opfs://temp.db.wal.recovery');
             };
 
-            const dropFiles = async (db: AsyncDuckDB) => {
-                await db.dropFiles([
+            const dropFiles = async (instance: AsyncDuckDB) => {
+                await instance.dropFiles([
                     'opfs://temp.db',
                     'opfs://temp.db.wal',
                     'opfs://temp.db.wal.checkpoint',


### PR DESCRIPTION
# Allow opening and dropping of OPFS databases

## Summary

This PR makes it possible to attach an OPFS-backed database (`opfs://...`), write to it, detach, and then cleanly drop the underlying files, so that another tab or another DuckDB Wasm instance can open them afterwards.

OPFS support has been the subject of many PRs. This one doesn't try to fix everything; it targets two specific goals:

1. **Allow OPFS files to be used.**
2. **Allow a full attach / detach cycle of an OPFS database.**

It explicitly does **not** address automatic file registration.

## Allow OPFS files to be used

Recent changes to how file paths are canonicalized caused the input `opfs://file.db` to be rewritten as `opfs:/file.db`, breaking OPFS paths.

**Fix:** add a special case in the `buffered_filesystem` canonicalize function that preserves the path when it starts with `opfs://`.

## Allow attach / detach cycle of an OPFS database

The goal is for `register files` → `attach` → `query DB` → `detach` → `drop files` to release all files. Getting there required three fixes:

### 1. Register all associated files

Registering just the DB path and the WAL isn't enough — the temporary files associated with the database must be registered as well.

### 2. Handle `moveFile` for OPFS

On detach/checkpoint, `storage_manager.cpp` moves `*.wal.checkpoint` to `*.wal`. Moving files isn't supported by the OPFS filesystem.

A proper implementation would delete the target, create a new file, and copy the source's contents into it. But Wasm can't run asynchronous functions here, so instead we assume the file is already registered and move the bytes directly from one OPFS file to another. This keeps both files open and registered in case they're needed again.

**Fix:** special-case `moveFile` for OPFS file handling.

### 3. Re-open file with correct flags

Even with the above, writes still failed with errors about writing to a read-only file. This appears to be because re-open swaps the file handle without setting the flags. Setting the flags fixes it.

**Known trade-off:** this fix breaks one HTTPFS test. I think that's acceptable — as a user, I wouldn't expect an error in that test. If anyone disagrees, let me know and we can look for an alternative solution.
