### PR TITLE
Azure Blob / ADLS Gen2 support (abfss/az → https+SAS) (read only)

### DIFF
--- a/actions/image/Dockerfile
+++ b/actions/image/Dockerfile
@@ -22,7 +22,11 @@ RUN apt-get update -qq \
     && export CHROME_BIN=/usr/bin/google-chrome \
     && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/google.list
 
-ARG EMSDK_VERSION="3.1.56"
+# Keep in sync with EMSCRIPTEN_VERSION in .github/workflows/main.yml. Older emsdk (e.g. 3.1.56)
+# emits per-export `var X = wasmExports["X"]` bindings — including getTempRet0/setTempRet0 — which
+# the export-slimming awk in scripts/wasm_build_lib.sh strips, breaking loadable (MAIN_MODULE)
+# builds (instantiation fails / i64 return values are truncated).
+ARG EMSDK_VERSION="3.1.71"
 RUN mkdir -p /opt/emsdk \
     && cd /opt/emsdk \
     && curl -SL https://github.com/emscripten-core/emsdk/archive/${EMSDK_VERSION}.tar.gz | tar -xz --strip-components=1 \

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -224,6 +224,7 @@ add_library(
   ${CMAKE_SOURCE_DIR}/src/functions/table_function_relation.cc
   ${CMAKE_SOURCE_DIR}/src/insert_options.cc
   ${CMAKE_SOURCE_DIR}/src/io/arrow_ifstream.cc
+  ${CMAKE_SOURCE_DIR}/src/io/azure_filesystem.cc
   ${CMAKE_SOURCE_DIR}/src/io/buffered_filesystem.cc
   ${CMAKE_SOURCE_DIR}/src/io/file_page_buffer.cc
   ${CMAKE_SOURCE_DIR}/src/io/file_stats.cc
@@ -309,6 +310,7 @@ if(NOT EMSCRIPTEN)
 #      ${CMAKE_SOURCE_DIR}/test/ast_test.cc
       ${CMAKE_SOURCE_DIR}/test/all_types_test.cc
       ${CMAKE_SOURCE_DIR}/test/arrow_casts_test.cc
+      ${CMAKE_SOURCE_DIR}/test/azure_filesystem_test.cc
       ${CMAKE_SOURCE_DIR}/test/bugs_test.cc
       ${CMAKE_SOURCE_DIR}/test/file_page_buffer_test.cc
       ${CMAKE_SOURCE_DIR}/test/glob_test.cc

--- a/lib/include/duckdb/web/io/azure_filesystem.h
+++ b/lib/include/duckdb/web/io/azure_filesystem.h
@@ -1,0 +1,85 @@
+#ifndef INCLUDE_DUCKDB_WEB_IO_AZURE_FILESYSTEM_H_
+#define INCLUDE_DUCKDB_WEB_IO_AZURE_FILESYSTEM_H_
+
+#include <string>
+
+#include "duckdb/common/file_system.hpp"
+
+namespace duckdb {
+class DatabaseInstance;
+}  // namespace duckdb
+
+namespace duckdb {
+namespace web {
+namespace io {
+
+/// Makes Azure Blob Storage / ADLS Gen2 URLs readable in DuckDB-Wasm *without* the native `azure`
+/// extension (which depends on the Azure C++ SDK and cannot be compiled to Wasm).
+///
+/// The native flow is: the `azure` extension registers a filesystem for the `abfss://` (and friends)
+/// schemes and talks to Azure through the SDK. In Wasm that extension is unavailable, so DuckDB's
+/// autoloader fails with "Extension 'azure' is not available" the moment an Iceberg table backed by
+/// ADLS is queried.
+///
+/// This filesystem closes that gap. It claims the Azure URL schemes — which also stops DuckDB from
+/// trying to autoload the missing extension — looks up the matching `azure` secret (as vended e.g.
+/// by an Iceberg REST catalog: `account_name` + a `connection_string` carrying a SAS token),
+/// rewrites the URL to a plain HTTPS Blob URL with the SAS token appended as the query string, and
+/// re-opens it through the regular HTTPS path that Wasm already supports via range requests.
+///
+/// Azure SAS tokens authorize purely via the query string, so — unlike S3 — no request signing is
+/// needed; the rewrite is all it takes.
+class AzureFileSystem : public duckdb::FileSystem {
+   public:
+    /// Register the `azure` secret type and this filesystem on a database instance.
+    static void Register(duckdb::DatabaseInstance &db);
+
+    /// The parts of an Azure URL needed to build the equivalent HTTPS URL.
+    struct UrlParts {
+        /// Storage account name. Empty for account-less schemes (`az://`, `azure://`), in which
+        /// case it is taken from the secret.
+        std::string account;
+        /// Full endpoint host carried by the URL, e.g. `acc.dfs.core.windows.net` (abfss) or
+        /// `acc.blob.core.windows.net` (wasbs). Empty for account-less schemes. Preserving it keeps
+        /// ADLS Gen2 (dfs) and Blob requests on the endpoint their SAS token was issued for.
+        std::string host;
+        /// Blob container (a.k.a. ADLS filesystem).
+        std::string container;
+        /// Path of the blob within the container.
+        std::string key;
+    };
+
+    /// Whether `path` uses an Azure scheme (abfss://, abfs://, az://, azure://, wasbs://, wasb://).
+    static bool IsAzureURL(const std::string &path);
+    /// Parse an Azure URL into its parts. Returns false if `path` is not an Azure URL.
+    static bool ParseAzureURL(const std::string &path, UrlParts &out);
+    /// Extract the SAS token from an Azure `connection_string` ("...;SharedAccessSignature=<sas>").
+    /// Any leading '?' is stripped. Returns an empty string if absent.
+    static std::string ExtractSasToken(const std::string &connection_string);
+    /// Extract the account name from an Azure `connection_string` ("AccountName=<acc>;...").
+    static std::string ExtractAccountName(const std::string &connection_string);
+    /// Build `https://<host>/<container>/<key>?<sas>` (host e.g. `acc.dfs.core.windows.net`).
+    static std::string BuildHttpsURL(const std::string &host, const std::string &container,
+                                     const std::string &key, const std::string &sas);
+
+    bool CanHandleFile(const string &fpath) override;
+    duckdb::unique_ptr<duckdb::FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+                                                    optional_ptr<FileOpener> opener) override;
+    bool FileExists(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
+    vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
+    std::string GetName() const override { return "AzureFileSystem"; }
+
+   private:
+    /// Resolve an Azure URL to an HTTPS Blob URL with the SAS token of the matching `azure` secret.
+    /// Throws a descriptive error if no usable secret is found.
+    static std::string ResolveHttpsURL(const std::string &path, optional_ptr<FileOpener> opener);
+    /// Re-open `path` (after resolving it to HTTPS) through the regular virtual filesystem so it
+    /// flows through the same buffered HTTPS read path as any other https:// file.
+    static duckdb::FileSystem &ResolveTargetFileSystem(optional_ptr<FileOpener> opener);
+};
+
+}  // namespace io
+}  // namespace web
+}  // namespace duckdb
+
+#endif  // INCLUDE_DUCKDB_WEB_IO_AZURE_FILESYSTEM_H_

--- a/lib/src/io/azure_filesystem.cc
+++ b/lib/src/io/azure_filesystem.cc
@@ -1,0 +1,226 @@
+#include "duckdb/web/io/azure_filesystem.h"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/web/io/web_filesystem.h"
+
+namespace duckdb {
+namespace web {
+namespace io {
+
+namespace {
+
+/// The Azure URL schemes we transparently read over HTTPS.
+/// `abfss`/`abfs`/`wasbs`/`wasb` embed the account in the host (`container@account.<host>`);
+/// `az`/`azure` do not, so their account comes from the secret.
+const char *AZURE_SCHEMES[] = {"abfss://", "abfs://", "az://", "azure://", "wasbs://", "wasb://"};
+
+/// Read the value of `key` (up to the next ';') from an Azure connection string.
+std::string ConnectionStringValue(const std::string &connection_string, const std::string &key) {
+    auto pos = connection_string.find(key);
+    if (pos == std::string::npos) {
+        return "";
+    }
+    std::string value = connection_string.substr(pos + key.size());
+    auto semicolon = value.find(';');
+    if (semicolon != std::string::npos) {
+        value = value.substr(0, semicolon);
+    }
+    return value;
+}
+
+/// Build the `azure` secret from the options the Iceberg extension passes to CREATE SECRET.
+unique_ptr<BaseSecret> CreateAzureSecretFromConfig(ClientContext &, CreateSecretInput &input) {
+    auto secret = make_uniq<KeyValueSecret>(input.scope, input.type, input.provider, input.name);
+    secret->TrySetValue("account_name", input);
+    secret->TrySetValue("connection_string", input);
+    secret->redact_keys = {"connection_string"};
+    return std::move(secret);
+}
+
+}  // namespace
+
+bool AzureFileSystem::IsAzureURL(const std::string &path) {
+    for (auto *scheme : AZURE_SCHEMES) {
+        if (StringUtil::StartsWith(path, scheme)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool AzureFileSystem::ParseAzureURL(const std::string &path, UrlParts &out) {
+    auto scheme_end = path.find("://");
+    if (scheme_end == std::string::npos) {
+        return false;
+    }
+    std::string scheme = path.substr(0, scheme_end);
+    std::string rest = path.substr(scheme_end + 3);
+
+    bool host_based = scheme == "abfss" || scheme == "abfs" || scheme == "wasbs" || scheme == "wasb";
+    bool account_less = scheme == "az" || scheme == "azure";
+    if (!host_based && !account_less) {
+        return false;
+    }
+
+    out = UrlParts{};
+    if (host_based) {
+        // container@account.<host>/key
+        auto at = rest.find('@');
+        if (at == std::string::npos) {
+            return false;
+        }
+        out.container = rest.substr(0, at);
+        std::string host_and_path = rest.substr(at + 1);
+        auto slash = host_and_path.find('/');
+        std::string host = slash == std::string::npos ? host_and_path : host_and_path.substr(0, slash);
+        out.key = slash == std::string::npos ? "" : host_and_path.substr(slash + 1);
+        out.host = host;
+        auto dot = host.find('.');
+        out.account = dot == std::string::npos ? host : host.substr(0, dot);
+    } else {
+        // container/key — account is supplied by the secret
+        auto slash = rest.find('/');
+        out.container = slash == std::string::npos ? rest : rest.substr(0, slash);
+        out.key = slash == std::string::npos ? "" : rest.substr(slash + 1);
+    }
+    return !out.container.empty();
+}
+
+std::string AzureFileSystem::ExtractSasToken(const std::string &connection_string) {
+    // SAS tokens never contain ';', but they do contain '=' and '&', so the value runs to the end
+    // of the "SharedAccessSignature=" segment.
+    std::string sas = ConnectionStringValue(connection_string, "SharedAccessSignature=");
+    if (!sas.empty() && sas.front() == '?') {
+        sas = sas.substr(1);
+    }
+    return sas;
+}
+
+std::string AzureFileSystem::ExtractAccountName(const std::string &connection_string) {
+    return ConnectionStringValue(connection_string, "AccountName=");
+}
+
+std::string AzureFileSystem::BuildHttpsURL(const std::string &host, const std::string &container,
+                                           const std::string &key, const std::string &sas) {
+    std::string url = "https://" + host + "/" + container;
+    if (!key.empty()) {
+        url += "/" + key;
+    }
+    if (!sas.empty()) {
+        url += "?" + sas;
+    }
+    return url;
+}
+
+std::string AzureFileSystem::ResolveHttpsURL(const std::string &path, optional_ptr<FileOpener> opener) {
+    UrlParts parts;
+    if (!ParseAzureURL(path, parts)) {
+        throw IOException("Cannot parse Azure URL '%s'", path);
+    }
+    if (!opener) {
+        throw IOException("Cannot resolve Azure URL '%s': no secret context (file opener) available", path);
+    }
+
+    // Look up the `azure` secret scoped to this path (e.g. vended by an Iceberg REST catalog).
+    FileOpenerInfo info;
+    info.file_path = path;
+    const char *secret_type = "azure";
+    KeyValueSecretReader secret_reader(*opener, &info, secret_type);
+
+    std::string connection_string;
+    secret_reader.TryGetSecretKey<std::string>("connection_string", connection_string);
+
+    std::string account = parts.account;
+    if (account.empty()) {
+        secret_reader.TryGetSecretKey<std::string>("account_name", account);
+    }
+    if (account.empty()) {
+        account = ExtractAccountName(connection_string);
+    }
+    std::string sas = ExtractSasToken(connection_string);
+
+    if (account.empty() || sas.empty()) {
+        throw IOException(
+            "No usable `azure` secret found for '%s'. DuckDB-Wasm reads Azure storage over HTTPS using a SAS "
+            "token, so it needs an `azure` secret whose `connection_string` carries a SharedAccessSignature "
+            "(e.g. vended by the Iceberg REST catalog).",
+            path);
+    }
+    // Preserve the endpoint host from the URL (abfss -> dfs, wasbs -> blob) so the request stays on
+    // the endpoint the SAS was issued for (e.g. a directory SAS `sr=d` is only valid on dfs).
+    // Account-less schemes (az://) carry no host; default to the Blob endpoint.
+    std::string host = !parts.host.empty() ? parts.host : account + ".blob.core.windows.net";
+    return BuildHttpsURL(host, parts.container, parts.key, sas);
+}
+
+duckdb::FileSystem &AzureFileSystem::ResolveTargetFileSystem(optional_ptr<FileOpener> opener) {
+    // Re-open through the database's filesystem so the rewritten https URL flows through the same
+    // buffered read path (FilePageBuffer) as any other https:// file. Callers must pass a null
+    // opener: that filesystem is an OpenerFileSystem which pushes the opener itself and rejects an
+    // explicit one. Fall back to the web filesystem when there is no database (e.g. in tests).
+    auto db = FileOpener::TryGetDatabase(opener);
+    if (db) {
+        return db->GetFileSystem();
+    }
+    auto *web_fs = WebFileSystem::Get();
+    if (!web_fs) {
+        throw IOException("Cannot resolve a target filesystem for Azure URLs");
+    }
+    return *web_fs;
+}
+
+bool AzureFileSystem::CanHandleFile(const string &fpath) { return IsAzureURL(fpath); }
+
+duckdb::unique_ptr<duckdb::FileHandle> AzureFileSystem::OpenFile(const string &path, FileOpenFlags flags,
+                                                                 optional_ptr<FileOpener> opener) {
+    auto https_url = ResolveHttpsURL(path, opener);
+    // Null opener: the target OpenerFileSystem pushes the current opener automatically (and the SAS
+    // is already in the URL, so no secret lookup is needed for the https read).
+    return ResolveTargetFileSystem(opener).OpenFile(https_url, flags, nullptr);
+}
+
+bool AzureFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
+    auto https_url = ResolveHttpsURL(filename, opener);
+    return ResolveTargetFileSystem(opener).FileExists(https_url, nullptr);
+}
+
+vector<OpenFileInfo> AzureFileSystem::Glob(const string &path, FileOpener *opener) {
+    // Iceberg reads explicit file paths, so globbing Azure URLs is never requested. Fail loudly
+    // rather than pretend to glob a single resolved blob.
+    (void)opener;
+    throw NotImplementedException("Globbing Azure (%s) paths is not supported in DuckDB-Wasm", path);
+}
+
+void AzureFileSystem::Register(duckdb::DatabaseInstance &db) {
+    // 1) Register a minimal `azure` secret type so the Iceberg extension can stash the SAS token it
+    //    vends (CREATE SECRET ... TYPE azure), even though the native `azure` extension is absent.
+    auto &secret_manager = db.GetSecretManager();
+
+    SecretType azure_secret_type;
+    azure_secret_type.name = "azure";
+    azure_secret_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+    azure_secret_type.default_provider = "config";
+    secret_manager.RegisterSecretType(azure_secret_type);
+
+    CreateSecretFunction config_function;
+    config_function.secret_type = "azure";
+    config_function.provider = "config";
+    config_function.function = CreateAzureSecretFromConfig;
+    config_function.named_parameters["account_name"] = LogicalType::VARCHAR;
+    config_function.named_parameters["connection_string"] = LogicalType::VARCHAR;
+    secret_manager.RegisterSecretFunction(config_function, OnCreateConflict::ERROR_ON_CONFLICT);
+
+    // 2) Register the filesystem for the Azure URL schemes. Claiming the schemes also stops DuckDB
+    //    from trying (and failing) to autoload the unavailable native `azure` extension.
+    db.GetFileSystem().RegisterSubSystem(make_uniq<AzureFileSystem>());
+}
+
+}  // namespace io
+}  // namespace web
+}  // namespace duckdb

--- a/lib/src/webdb.cc
+++ b/lib/src/webdb.cc
@@ -57,6 +57,7 @@
 #include "duckdb/web/functions/table_function_relation.h"
 #include "duckdb/web/http_wasm.h"
 #include "duckdb/web/io/arrow_ifstream.h"
+#include "duckdb/web/io/azure_filesystem.h"
 #include "duckdb/web/io/buffered_filesystem.h"
 #include "duckdb/web/io/file_page_buffer.h"
 #include "duckdb/web/io/ifstream.h"
@@ -995,6 +996,10 @@ arrow::Status WebDB::Open(std::string_view args_json) {
         if (!config.encryption_util) {
             config.encryption_util = make_shared_ptr<duckdb_mbedtls::MbedTlsWrapper::AESStateMBEDTLSFactory>();
         }
+
+        // Make Azure Blob / ADLS Gen2 URLs (abfss://, az://, ...) readable over HTTPS without the
+        // native `azure` extension, which cannot be compiled to Wasm. See AzureFileSystem.
+        io::AzureFileSystem::Register(*db->instance);
 
         // Reset state that is specific to the old database
         connections_.clear();

--- a/lib/test/azure_filesystem_test.cc
+++ b/lib/test/azure_filesystem_test.cc
@@ -1,0 +1,86 @@
+#include "duckdb/web/io/azure_filesystem.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+using namespace duckdb::web::io;
+using namespace std;
+
+namespace {
+
+TEST(AzureFileSystem, IsAzureURL) {
+    EXPECT_TRUE(AzureFileSystem::IsAzureURL("abfss://fs@acc.dfs.core.windows.net/a/b.parquet"));
+    EXPECT_TRUE(AzureFileSystem::IsAzureURL("abfs://fs@acc.dfs.core.windows.net/a"));
+    EXPECT_TRUE(AzureFileSystem::IsAzureURL("wasbs://fs@acc.blob.core.windows.net/a"));
+    EXPECT_TRUE(AzureFileSystem::IsAzureURL("az://container/a/b.parquet"));
+    EXPECT_TRUE(AzureFileSystem::IsAzureURL("azure://container/a"));
+
+    EXPECT_FALSE(AzureFileSystem::IsAzureURL("https://acc.blob.core.windows.net/fs/a"));
+    EXPECT_FALSE(AzureFileSystem::IsAzureURL("s3://bucket/key"));
+    EXPECT_FALSE(AzureFileSystem::IsAzureURL("/local/path"));
+}
+
+TEST(AzureFileSystem, ParseHostBasedURL) {
+    AzureFileSystem::UrlParts parts;
+    ASSERT_TRUE(
+        AzureFileSystem::ParseAzureURL("abfss://myfs@myaccount.dfs.core.windows.net/dir/file.parquet", parts));
+    EXPECT_EQ(parts.account, "myaccount");
+    EXPECT_EQ(parts.host, "myaccount.dfs.core.windows.net");
+    EXPECT_EQ(parts.container, "myfs");
+    EXPECT_EQ(parts.key, "dir/file.parquet");
+}
+
+TEST(AzureFileSystem, ParseAccountLessURL) {
+    AzureFileSystem::UrlParts parts;
+    ASSERT_TRUE(AzureFileSystem::ParseAzureURL("az://mycontainer/dir/file.parquet", parts));
+    EXPECT_EQ(parts.account, "");  // account must come from the secret
+    EXPECT_EQ(parts.container, "mycontainer");
+    EXPECT_EQ(parts.key, "dir/file.parquet");
+}
+
+TEST(AzureFileSystem, ParseRejectsNonAzure) {
+    AzureFileSystem::UrlParts parts;
+    EXPECT_FALSE(AzureFileSystem::ParseAzureURL("https://acc.blob.core.windows.net/fs/a", parts));
+    EXPECT_FALSE(AzureFileSystem::ParseAzureURL("no-scheme", parts));
+}
+
+TEST(AzureFileSystem, ExtractSasToken) {
+    EXPECT_EQ(AzureFileSystem::ExtractSasToken("AccountName=acc;SharedAccessSignature=sv=2022&ss=b&sig=abc%3D"),
+              "sv=2022&ss=b&sig=abc%3D");
+    // A leading '?' is stripped.
+    EXPECT_EQ(AzureFileSystem::ExtractSasToken("AccountName=acc;SharedAccessSignature=?sv=2022&sig=xyz"),
+              "sv=2022&sig=xyz");
+    // SharedAccessSignature may appear first.
+    EXPECT_EQ(AzureFileSystem::ExtractSasToken("SharedAccessSignature=sv=2022&sig=xyz;AccountName=acc"),
+              "sv=2022&sig=xyz");
+    EXPECT_EQ(AzureFileSystem::ExtractSasToken("AccountName=acc"), "");
+}
+
+TEST(AzureFileSystem, ExtractAccountName) {
+    EXPECT_EQ(AzureFileSystem::ExtractAccountName("AccountName=acc;SharedAccessSignature=sv=2022"), "acc");
+    EXPECT_EQ(AzureFileSystem::ExtractAccountName("SharedAccessSignature=sv=2022"), "");
+}
+
+TEST(AzureFileSystem, BuildHttpsURL) {
+    EXPECT_EQ(
+        AzureFileSystem::BuildHttpsURL("acc.dfs.core.windows.net", "fs", "dir/file.parquet", "sv=2022&sig=xyz"),
+        "https://acc.dfs.core.windows.net/fs/dir/file.parquet?sv=2022&sig=xyz");
+    // No key, no SAS.
+    EXPECT_EQ(AzureFileSystem::BuildHttpsURL("acc.blob.core.windows.net", "fs", "", ""),
+              "https://acc.blob.core.windows.net/fs");
+}
+
+// End-to-end of the pure rewrite: abfss:// + connection string -> https Blob URL with SAS.
+TEST(AzureFileSystem, RewriteHostBasedToHttps) {
+    AzureFileSystem::UrlParts parts;
+    ASSERT_TRUE(
+        AzureFileSystem::ParseAzureURL("abfss://myfs@myaccount.dfs.core.windows.net/dir/file.parquet", parts));
+    const string connection_string = "AccountName=myaccount;SharedAccessSignature=sv=2022&ss=b&sig=abc%3D";
+    auto sas = AzureFileSystem::ExtractSasToken(connection_string);
+    // Host preserved from the abfss URL (dfs endpoint), so a directory SAS stays valid.
+    auto url = AzureFileSystem::BuildHttpsURL(parts.host, parts.container, parts.key, sas);
+    EXPECT_EQ(url, "https://myaccount.dfs.core.windows.net/myfs/dir/file.parquet?sv=2022&ss=b&sig=abc%3D");
+}
+
+}  // namespace


### PR DESCRIPTION
Hello, I was working with Lakekeeper Iceberg Catalog when I noticed the built-in duckdb-wasm does not support reading iceberg tables from azure blob storage, because of missing azure auth library in wasm.

I got inspired by https://github.com/duckdb/duckdb-wasm/discussions/2217 and took my chance at implementing this feature. It works. I tried to make the changes as minimal/straight-forward as possible, but I would highly appreciate if someone experienced would take a look at it and cleaned it up / suggested improvements.

Before:

https://github.com/user-attachments/assets/5b7fada3-3b93-442b-9589-afbe1bd2f2e3

After:

https://github.com/user-attachments/assets/cf18a093-a166-45cf-a080-92210efb1427


**What it does**                                                                                                                                                                                                      
                                                                                                                                                                                                                    
  Adds an AzureFileSystem to the wasm layer that can access Azure Blob / ADLS Gen2 paths (abfss://, abfs://, az://, azure://, wasbs://, wasb://) over HTTPS using a SAS token — without the native azure extension, which
  can't be compiled to wasm.                                                                                                                                                                                        
                                                                                                                                                                                                                    
  Mechanism (three parts):                                                                                                                                                                                          
  1. Registers an azure secret type (provider config: account_name, connection_string) so that CREATE SECRET ... TYPE azure — issued by the Iceberg extension from vended credentials — succeeds.                   
  2. Registers the filesystem as a VFS subsystem that claims the Azure URL schemes. This also stops DuckDB from trying to autoload the unavailable native azure extension (today this fails with "Extension 'azure' 
  is not available").                                                                                                                                                                                               
  3. On open: looks up the matching azure secret (scoped to the original abfss:// path), rewrites the URL to HTTPS preserving the endpoint host (abfss→dfs, wasbs→blob), appends the SAS token as the query string, 
  and re-opens it through the buffered VFS as a regular https:// file. The SAS authorizes via the query string, so there is no request signing (unlike S3).                                                         
                                                                                                                                                                                                                    
  **What it brings**                                                                                                                                                                                                    
                                                                                                                                                                                                                    
  - Lets you query Iceberg tables stored on ADLS Gen2 directly from the browser (e.g. via a Lakekeeper REST catalog). Today this fails at azure-extension autoload.                                                 
  - Reuses the existing wasm HTTPS range-read path — no Azure SDK, no new runtime dependencies
  - No request signing; reads go through the same buffered path as s3/https.                                                                                                                                        
                                                                                                                                                                                                                    
  **Why not port the Azure SDK to wasm?**                                                                                                                                                                               
                                                                                                                                                                                                                    
  The alternative would be compiling DuckDB's azure extension (Azure SDK for C++) to wasm. 
  - No wasm build of the Azure C++ SDK exists (official or community). Its default transport is libcurl/WinHTTP, which don't work in browser wasm. A port is feasible — the SDK has a pluggable HttpTransport, so   
  one could implement an emscripten-fetch transport and build azure-core + azure-storage-* with crypto backed by the already-present mbedtls — but it is substantial work with no upstream support.                 
  - It buys little for the browser case. A browser has no managed identity / interactive AAD flow, so authentication is effectively limited to SAS/tokens regardless of the SDK. For read access via a vended SAS,  
  the full SDK is overkill: a URL rewrite covers it at a fraction of the cost.                                                                                                                                      
  - The SDKs that do run in a browser/wasm context are the wrong layer for this: the JS SDK (@azure/storage-blob) can't be called from the C++ extension, and the Rust SDK targets server-side WASI, not the        
  browser.                                                                                                                                                                                                          
                                                                                                                                                                                                                    
  **Scope / limitations**                                                                                                                                                                                               
                                                                                                                                                                                                                    
  - Works only with vended credentials by the catalog (requires an azure secret whose connection_string carries a SharedAccessSignature). No AAD/managed-identity auth.                                                                                                              
  - ADLS Gen1 (adl://) is not supported (the service was retired in 2024).                                                                                                                                          
  - Glob / directory operations on Azure paths are not implemented (NotImplementedException) — Iceberg uses explicit file paths.                                                                                    
  - The browser must be able to reach the storage account: cross-origin access requires CORS on the storage account (allow the UI origin, GET/HEAD/OPTIONS, the Range request header, and expose                    
  Content-Range/Content-Length). In the Lakekeeper UI the catalog itself is same-origin, so only ADLS needs CORS.                                                                                                   
  - Directory-scoped SAS (sr=d, as vended by Lakekeeper) is only valid on the dfs endpoint — hence host preservation rather than forcing the blob endpoint.                                                         
                                                                                                                                                                                                                    
  Tests                                                                                                                                                                                                             
                                                                                                                                                                                                                    
  Unit tests for URL parsing, SAS extraction, and the rewrite. Verified end-to-end against a Lakekeeper REST catalog over a real ADLS Gen2 table.
