### PR TITLE
fix(wasm): forward HTTPFSParams::bearer_token as Authorization header

### DIFF
--- a/lib/src/http_wasm.cc
+++ b/lib/src/http_wasm.cc
@@ -24,6 +24,12 @@ HTTPHeaders TransformHeadersWasm(const HTTPHeaders &header_map, const HTTPParams
             res_headers.Insert(entry.first, entry.second);
         }
     }
+    // Native clients turn a bearer_token secret into an Authorization header automatically;
+    // the WASM client never did, so authenticated requests (e.g. gated hf:// repos) went out
+    // unauthenticated. An explicit Authorization header already set still takes precedence.
+    if (!httpfs_params.bearer_token.empty() && !res_headers.HasHeader("Authorization")) {
+        res_headers.Insert("Authorization", "Bearer " + httpfs_params.bearer_token);
+    }
     return res_headers;
 }
 


### PR DESCRIPTION
Fixes #2253

I ran into this while trying to read a gated Hugging Face dataset from the browser. `CREATE SECRET (TYPE huggingface, TOKEN '...')` works fine, but the actual request never carries the token - checked the Network tab and there's just no `Authorization` header at all.

Turns out the native clients (httplib/curl) handle this for you: they take `bearer_token` from the secret and turn it into an `Authorization: Bearer ...` header automatically. The WASM client never did that step, so the token was just sitting in `HTTPFSParams` unused.

Fix is one `if` in `TransformHeadersWasm` - if there's a `bearer_token` and no `Authorization` header already set, add one. Tested it against a real gated dataset in the browser and it works now.

Shouldn't affect anything else - `bearer_token` is only ever non-empty when a matching secret with a token exists, so anonymous/S3/other secret types behave exactly like before.